### PR TITLE
Restore Additional Argument options

### DIFF
--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -487,7 +487,6 @@ function handleEndCmdDisplay(resp) {
 function enableTestControls(enable) {
     $("#button_cmd").prop('disabled', !enable);
     $("#button_reset").prop('disabled', !enable);
-    $("#addl_opt").prop('disabled', !enable);
 }
 
 function lockTab(href) {

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -96,7 +96,7 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, string(data))
 }
 
-func parseRequest2BwtestItem(r *http.Request, appSel string) *model.BwTestItem {
+func parseRequest2BwtestItem(r *http.Request, appSel string) (*model.BwTestItem, string) {
     d := new(model.BwTestItem)
     d.SIa = r.PostFormValue("ia_ser")
     d.CIa = r.PostFormValue("ia_cli")
@@ -104,6 +104,7 @@ func parseRequest2BwtestItem(r *http.Request, appSel string) *model.BwTestItem {
     d.CAddr = r.PostFormValue("addr_cli")
     d.SPort, _ = strconv.Atoi(r.PostFormValue("port_ser"))
     d.CPort, _ = strconv.Atoi(r.PostFormValue("port_cli"))
+    addl_opt := r.PostFormValue("addl_opt")
     if appSel == "bwtester" {
         d.CSDuration, _ = strconv.Atoi(r.PostFormValue("dial-cs-sec"))
         d.CSPktSize, _ = strconv.Atoi(r.PostFormValue("dial-cs-size"))
@@ -116,7 +117,7 @@ func parseRequest2BwtestItem(r *http.Request, appSel string) *model.BwTestItem {
         d.SCBandwidth = d.SCPackets * d.SCPktSize / d.SCDuration * 8
         d.SCDuration = d.SCDuration * 1000 // final storage in ms
     }
-    return d
+    return d, addl_opt
 }
 
 func parseBwTest2Cmd(d *model.BwTestItem, appSel string) []string {
@@ -169,8 +170,9 @@ func commandHandler(w http.ResponseWriter, r *http.Request) {
         }
     } else {
         // single run
-        d := parseRequest2BwtestItem(r, appSel)
+        d, addl_opt := parseRequest2BwtestItem(r, appSel)
         command := parseBwTest2Cmd(d, appSel)
+        command = append(command, addl_opt)
 
         // execute scion go client app with client/server commands
         log.Printf("Executing: %s\n", strings.Join(command, " "))
@@ -200,8 +202,9 @@ func continuousBwTest() {
         r := bwRequest
         r.ParseForm()
         appSel := r.PostFormValue("apps")
-        d := parseRequest2BwtestItem(r, appSel)
+        d, addl_opt := parseRequest2BwtestItem(r, appSel)
         command := parseBwTest2Cmd(d, appSel)
+        command = append(command, addl_opt)
 
         log.Printf("Executing: %s\n", strings.Join(command, " "))
         cmd := exec.Command(command[0], command[1:]...)


### PR DESCRIPTION
Thanks to @FR4NK-W, the operation of Additional Argument field is restored for adding additional parameters to test execution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/1)
<!-- Reviewable:end -->
