### PR TITLE
[pathdb_dump] Fix -t option timestamp

### DIFF
--- a/tools/pathdb_dump/pathdb_dump.go
+++ b/tools/pathdb_dump/pathdb_dump.go
@@ -73,7 +73,7 @@ func newSegment(segType proto.PathSegType, srcI addr.ISD, srcA addr.AS, dstI add
 	interfaces []asIface, updateTime, expiryTime int64) segment {
 
 	return segment{SegType: segType, Src: addr.IA{I: srcI, A: srcA}, Dst: addr.IA{I: dstI, A: dstA},
-		interfaces: interfaces, Updated: time.Unix(0, updateTime), Expiry: time.Unix(0, expiryTime)}
+		interfaces: interfaces, Updated: time.Unix(0, updateTime), Expiry: time.Unix(expiryTime, 0)}
 }
 
 func (s segment) toString(showTimestamps bool) string {

--- a/tools/pathdb_dump/pathdb_dump.go
+++ b/tools/pathdb_dump/pathdb_dump.go
@@ -80,7 +80,7 @@ func (s segment) toString(showTimestamps bool) string {
 	toRet := s.SegType.String() + "\t"
 	now := time.Now()
 	updatedStr := now.Sub(s.Updated).String()
-	expiryStr := now.Sub(s.Expiry).String()
+	expiryStr := s.Expiry.Sub(now).String()
 	toRet += ifsArrayToString(s.interfaces)
 	if showTimestamps {
 		toRet += "\tUpdated: " + updatedStr + "\t: Expires in: " + expiryStr


### PR DESCRIPTION
The database seems to store one timestamp in seconds and the other in nanoseconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/46)
<!-- Reviewable:end -->
