### PR TITLE
[webapp] Fixed errors when static files not found

### DIFF
--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -199,13 +199,10 @@ function drawBwtestSingleDir(dir, yAxisLabel, legend, reqCol, achCol) {
             floating : true,
             enabled : true,
         },
-
-        //TODO: run_loc: Download Data, location failed needs better error
-
         credits : {
             enabled : legend,
             text : legend ? 'Download Data' : null,
-            href : legend ? './files/webapp/data/' : null,
+            href : legend ? './data/' : null,
         },
         exporting : {
             enabled : false

--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -466,6 +466,9 @@ function command(continuous) {
         } else {
             handleGeneralResponse();
         }
+    }).fail(function(error) {
+        showError(error.responseJSON);
+        handleGeneralResponse();
     });
     // onsubmit should always return false to override native http call
     return false;

--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -199,6 +199,9 @@ function drawBwtestSingleDir(dir, yAxisLabel, legend, reqCol, achCol) {
             floating : true,
             enabled : true,
         },
+
+        //TODO: run_loc: Download Data, location failed needs better error
+
         credits : {
             enabled : legend,
             text : legend ? 'Download Data' : null,

--- a/webapp/template/footer.html
+++ b/webapp/template/footer.html
@@ -1,5 +1,7 @@
 {{define "footer"}}
 <script>
+    //TODO: run_loc: make sure keep alive works, likely that all posts have timeouts
+
     $(document).ready(
             function() {
                 $.ajaxSetup({

--- a/webapp/template/footer.html
+++ b/webapp/template/footer.html
@@ -1,7 +1,5 @@
 {{define "footer"}}
 <script>
-    //TODO: run_loc: make sure keep alive works, likely that all posts have timeouts
-
     $(document).ready(
             function() {
                 $.ajaxSetup({

--- a/webapp/template/health.html
+++ b/webapp/template/health.html
@@ -26,6 +26,9 @@
 
 <script>
     $("#health-list").empty();
+
+    //TODO: run_loc: /healthcheck needs to timeout response when wrong rundir
+
     $.post("/healthcheck", null, function(data) {
         d = JSON.parse(data);
         console.info('resp:', JSON.stringify(d));

--- a/webapp/template/health.html
+++ b/webapp/template/health.html
@@ -8,8 +8,8 @@
 
  <h2>SCIONLab Health Check</h2>
  <p>
-  If all automated tests have passed, please continue to <a
-   href="/apps">Apps</a> in the menu to use SCIONLab.
+  If all automated tests have passed, please continue to <a href="/apps">Apps</a>
+  in the menu to use SCIONLab.
  </p>
  <ul id="health-list">
  </ul>
@@ -32,6 +32,8 @@
         if (d.err) {
             showError(d.err);
         }
+    }).fail(function(error) {
+        showError(error.responseJSON);
     });
     var last = [];
     var healthInterval = setInterval(function() {
@@ -71,9 +73,13 @@
                             "Check last completed " + now.toLocaleDateString()
                                     + " " + now.toLocaleTimeString() + ".");
                 }
+            },
+            error : function(jqXHR, textStatus, errorThrown) {
+                showError(this.url + ' ' + textStatus + ': ' + errorThrown);
+                clearInterval(healthInterval);
             }
         });
-    }, 500);
+    }, 1000);
 
     function getListItemDiv(resp, test) {
         var a = $('<a>').attr('href', "#hc-" + test).attr('class',

--- a/webapp/template/health.html
+++ b/webapp/template/health.html
@@ -26,9 +26,6 @@
 
 <script>
     $("#health-list").empty();
-
-    //TODO: run_loc: /healthcheck needs to timeout response when wrong rundir
-
     $.post("/healthcheck", null, function(data) {
         d = JSON.parse(data);
         console.info('resp:', JSON.stringify(d));
@@ -40,7 +37,7 @@
     var healthInterval = setInterval(function() {
         // setup interval to check status file webserver will update
         $.ajax({
-            url : "files/data/healthcheck-result.json",
+            url : "data/healthcheck-result.json",
             method : 'GET',
             dataType : "json",
             success : function(data) {

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -59,6 +59,13 @@ type Page struct {
 
 func main() {
     flag.Parse()
+
+    //TODO: run_loc: needs to faile when /static and other files not found, must panic
+
+    //TODO: run_loc: maybe need to centralize location of root folder in libs
+
+    //TODO: run_loc: add command line option -webdir, default to CWD
+
     _, srcfile, _, _ := runtime.Caller(0)
     srcpath = path.Dir(srcfile)
 


### PR DESCRIPTION
This change adds a command line option for web server static files location `-s` defaulting to `.`. If the location of `-s` does not include a the proper static files folder, the webapp will panic. There are also various imprvements to web pages to handle errors in missed cases communicating with the web server.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/51)
<!-- Reviewable:end -->
