### PR TITLE
shttp: Close connections

### DIFF
--- a/lib/scionutil/initialization.go
+++ b/lib/scionutil/initialization.go
@@ -15,14 +15,16 @@
 package scionutil
 
 import (
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
+	"os"
 )
 
 // InitSCION initializes the default SCION networking context with the provided SCION address
 // and the default SCIOND/SCION dispatcher
 func InitSCION(localAddr *snet.Addr) error {
-	err := snet.Init(localAddr.IA, GetDefaultSCIOND(), GetDefaultDispatcher())
+	err := snet.Init(localAddr.IA, GetSCIONDPath(&localAddr.IA), GetDefaultDispatcher())
 	if err != nil {
 		return err
 	}
@@ -37,7 +39,7 @@ func InitSCIONString(localAddr string) (*snet.Addr, error) {
 		return nil, err
 	}
 
-	err = snet.Init(addr.IA, GetDefaultSCIOND(), GetDefaultDispatcher())
+	err = snet.Init(addr.IA, GetSCIONDPath(&addr.IA), GetDefaultDispatcher())
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +47,15 @@ func InitSCIONString(localAddr string) (*snet.Addr, error) {
 	return addr, nil
 }
 
-// GetDefaultSCIOND returns the path to the default SCION socket
-func GetDefaultSCIOND() string {
-	return sciond.GetDefaultSCIONDPath(nil)
+// GetSCIONDPath returns the path to the SCION socket.
+func GetSCIONDPath(ia *addr.IA) string {
+
+	// Use default.sock if exists:
+	if _, err := os.Stat(sciond.DefaultSCIONDPath); err == nil {
+		return sciond.DefaultSCIONDPath
+	}
+	// otherwise, use socket with ia name:
+	return sciond.GetDefaultSCIONDPath(ia)
 }
 
 // GetDefaultDispatcher returns the path to the default SCION dispatcher

--- a/lib/shttp/examples/minimal/README.md
+++ b/lib/shttp/examples/minimal/README.md
@@ -2,18 +2,23 @@ This example application makes two requests from the client to the server.
 
 First, it issues a GET request and downloads an HTML file. Afterwards it sends data to the server via POST.
 
-To run the example, first start the server like this
-```Go
-go run server.go -local 17-ffaa:1:c2,[127.0.0.1]:40002 -cert tls.pem -key tls.key
+To run the example, generate a certificate for the server first, e.g
+```sh
+openssl req -x509 -newkey rsa:1024 -keyout key.pem -nodes -out cert.pem -days 365 -subj '/CN=minimal-server'
+```
+
+Start the server like this
+```sh
+go run server.go -local 17-ffaa:1:c2,[127.0.0.1]:40002 -cert cert.pem -key key.pem
 ```
 
 Then, start the client:
-```Go
+```sh
 go run client.go -local 17-ffaa:1:c2,[127.0.0.1]:0
 ```
 
 For an interactive mode that lets the user choose a path from all available paths add the `-i` flag:
-```Go
+```sh
 go run client.go -local 17-ffaa:1:c2,[127.0.0.1]:0 -i
 ```
 


### PR DESCRIPTION
Workaround squic: explicitly close connections

Due to behavior changes in quic-go, any session created with squic.DialSCION will leak the underlying snet.Conn -- the quic.Session will simply not call Close on a connection passed in. (See https://github.com/scionproto/scion/issues/2539).

Re-implement the small squic.DialSCION functions to get access to the snet.Conn to close them later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/54)
<!-- Reviewable:end -->
