### PR TITLE
shttp: allow scion-address in url

### DIFF
--- a/bat/bat.go
+++ b/bat/bat.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -176,6 +177,15 @@ func main() {
 
 	if *URL == "" {
 		usage()
+	}
+
+	addrRegexp := regexp.MustCompile(`^(https?://)?(\d+-[[:xdigit:]]{1,4}:[[:xdigit:]]{1,4}:[[:xdigit:]]{1,4},\[[^]]+\])`)
+	matches := addrRegexp.FindSubmatch([]byte(*URL))
+	if matches != nil {
+		err := scionutil.AddHost("__bat_host__", string(matches[2]))
+		if err == nil {
+			*URL = addrRegexp.ReplaceAllString(*URL, `${1}__bat_host__`)
+		}
 	}
 
 	if strings.HasPrefix(*URL, ":") {

--- a/bat/bat.go
+++ b/bat/bat.go
@@ -32,7 +32,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -177,15 +176,6 @@ func main() {
 
 	if *URL == "" {
 		usage()
-	}
-
-	addrRegexp := regexp.MustCompile(`^(https?://)?(\d+-[[:xdigit:]]{1,4}:[[:xdigit:]]{1,4}:[[:xdigit:]]{1,4},\[[^]]+\])`)
-	matches := addrRegexp.FindSubmatch([]byte(*URL))
-	if matches != nil {
-		err := scionutil.AddHost("__bat_host__", string(matches[2]))
-		if err == nil {
-			*URL = addrRegexp.ReplaceAllString(*URL, `${1}__bat_host__`)
-		}
 	}
 
 	if strings.HasPrefix(*URL, ":") {

--- a/lib/shttp/transport.go
+++ b/lib/shttp/transport.go
@@ -98,7 +98,7 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt h2quic.RoundTripOpt) (*h
 	// If req.URL.Host is a SCION address, we need to mangle it so it passes through
 	// h2quic without tripping up.
 	raddr, err := snet.AddrFromString(req.URL.Host)
-	if raddr != nil && err == nil {
+	if err == nil {
 		tmp := *req
 		tmp.URL = new(url.URL)
 		*tmp.URL = *req.URL


### PR DESCRIPTION
Even when having names, it's convenient to be able to use addresses directly. This patch allows to scion-addresses in the conventional format in URLs for ~~bat~~ shttp.

~~Maybe this could be made into a feature of the shttp library, but I don't know where to put it without wrapping the entire Client.~~ (Done)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/59)
<!-- Reviewable:end -->
