### PR TITLE
Fixed build and added missing vendor entries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ sensorapp/sensorfetcher/sensorfetcher
 sensorapp/sensorserver/sensorserver
 webapp/webapp
 tools/pathdb_dump/pathdb_dump
+netcat/netcat
+roughtime/timeclient/timeclient
+roughtime/timeserver/timeserver

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 .PHONY: all clean
 
 ROOT_DIR=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-# TODO: missing roughtime/timeserver roughtime/timeclient
-SRCDIRS= helloworld sensorapp/sensorserver sensorapp/sensorfetcher camerapp/imageserver camerapp/imagefetcher bwtester/bwtestserver bwtester/bwtestclient webapp bat bat/example_server tools/pathdb_dump netcat
+SRCDIRS= helloworld sensorapp/sensorserver sensorapp/sensorfetcher camerapp/imageserver camerapp/imagefetcher bwtester/bwtestserver bwtester/bwtestclient webapp bat bat/example_server tools/pathdb_dump roughtime/timeserver roughtime/timeclient netcat
 TARGETS = $(foreach D,$(SRCDIRS),$(D)/$(notdir $(D)))
 
 all: $(TARGETS)

--- a/roughtime/README.md
+++ b/roughtime/README.md
@@ -8,18 +8,10 @@ This implementation also allows users who have a [ThinkerForge](https://www.tink
 
 ## Build
 
-Install roughtime library:
-
-```
-cd $GOPATH/src/
-git clone https://roughtime.googlesource.com/roughtime roughtime.googlesource.com
-```
-
 Build server:
 
 ```
 cd $GOPATH/src/github.com/netsec-ethz/scion-apps/roughtime/timeserver
-go get
 go build
 ```
 
@@ -27,7 +19,6 @@ Build client:
 
 ```
 cd $GOPATH/src/github.com/netsec-ethz/scion-apps/roughtime/timeclient
-go get
 go build
 ```
 

--- a/roughtime/timeserver/main.go
+++ b/roughtime/timeserver/main.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/netsec-ethz/scion-apps/lib/scionutil"
 	"github.com/netsec-ethz/scion-apps/roughtime/utils"
 	"github.com/scionproto/scion/go/lib/snet"
 	"golang.org/x/crypto/ed25519"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"roughtime.googlesource.com/go/protocol"
 )
 
@@ -61,7 +62,7 @@ func runServers(configurationFile, privateKeyFile string) {
 }
 
 func serveRequests(bindAddress, connectionProtocol, timedLocation string, privateKey []byte) {
-	sAddr, err := utils.InitSCIONConnection(bindAddress)
+	sAddr, err := scionutil.InitSCIONString(bindAddress)
 	checkErr("Initializing SCION connection", err)
 
 	conn, err := snet.ListenSCION(connectionProtocol, sAddr)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -888,6 +888,30 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		},
 		{
+			"checksumSHA1": "d+FszpdwcrSQzdoG3w0E2FxQnFQ=",
+			"comment": "using this fork in github until we know how to govendor fetch from the real path",
+			"origin": "github.com/juagargi/roughtime/go/client/monotime",
+			"path": "roughtime.googlesource.com/go/client/monotime",
+			"revision": "26225bef2678cedbd88baa8a22b85f267a6e88b5",
+			"revisionTime": "2018-10-29T22:37:29Z"
+		},
+		{
+			"checksumSHA1": "dtUYa81+BOxmiK4NjluVowO8g0U=",
+			"comment": "using this fork in github until we know how to govendor fetch from the real path",
+			"origin": "github.com/juagargi/roughtime/go/config",
+			"path": "roughtime.googlesource.com/go/config",
+			"revision": "26225bef2678cedbd88baa8a22b85f267a6e88b5",
+			"revisionTime": "2018-10-29T22:37:29Z"
+		},
+		{
+			"checksumSHA1": "7TVC3xVndRMynYSO7L/fQG6QIkk=",
+			"comment": "using this fork in github until we know how to govendor fetch from the real path",
+			"origin": "github.com/juagargi/roughtime/go/protocol",
+			"path": "roughtime.googlesource.com/go/protocol",
+			"revision": "26225bef2678cedbd88baa8a22b85f267a6e88b5",
+			"revisionTime": "2018-10-29T22:37:29Z"
+		},
+		{
 			"checksumSHA1": "Vu7yTzds3lfhARaEKI/8vmhIvLg=",
 			"license": "MIT",
 			"path": "zombiezen.com/go/capnproto2",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -729,6 +729,12 @@
 			"revisionTime": "2018-06-07T13:59:11Z"
 		},
 		{
+			"checksumSHA1": "eP6ULb7qY83lyYmM7AfaDIRDeXE=",
+			"path": "golang.org/x/crypto/sha3",
+			"revision": "3d3f9f413869b949e48070b5bc593aa22cc2b8f2",
+			"revisionTime": "2018-11-10T06:03:37Z"
+		},
+		{
 			"checksumSHA1": "CQYQ8wELyxPMRYOTDLELVtude/M=",
 			"path": "golang.org/x/image/font",
 			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
@@ -745,6 +751,12 @@
 			"path": "golang.org/x/image/math/fixed",
 			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
 			"revisionTime": "2019-03-12T13:36:53Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "c7086645de248775cbf2373cf5ca4d2fa664b8c1",
+			"revisionTime": "2017-11-10T09:49:23Z"
 		},
 		{
 			"checksumSHA1": "pCY4YtdNKVBYRbNvODjx8hj0hIs=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -152,13 +152,6 @@
 			"revisionTime": "2018-10-23T10:10:25Z"
 		},
 		{
-			"checksumSHA1": "P3zGmsNjW8m15a+nks4FdVpFKwE=",
-			"license": "2-BSD",
-			"path": "github.com/gopherjs/gopherjs/js",
-			"revision": "6f5a3c4a73badf117936d7d61a046e2fab8e2adb",
-			"revisionTime": "2016-10-23T18:47:00Z"
-		},
-		{
 			"checksumSHA1": "UquR8kc0nKU285HwLbkievlLQz4=",
 			"path": "github.com/hashicorp/golang-lru",
 			"revision": "0fb14efe8c47ae851c0034ed7a448854d3d34cf3",
@@ -752,12 +745,6 @@
 			"path": "golang.org/x/image/math/fixed",
 			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
 			"revisionTime": "2019-03-12T13:36:53Z"
-		},
-		{
-			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
-			"path": "golang.org/x/net/context",
-			"revision": "c7086645de248775cbf2373cf5ca4d2fa664b8c1",
-			"revisionTime": "2017-11-10T09:49:23Z"
 		},
 		{
 			"checksumSHA1": "pCY4YtdNKVBYRbNvODjx8hj0hIs=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -676,30 +676,6 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "Vzb+dEH/LTYbvr8RXHmt6xJHz04=",
-			"license": "3-BSD",
-			"path": "github.com/smartystreets/assertions/internal/go-render/render",
-			"revision": "2063fd1cc7c975db70502811a34b06ad034ccdf2",
-			"revisionTime": "2016-07-07T19:03:55Z"
-		},
-		{
-			"checksumSHA1": "SLC6TfV4icQA9l8YJQu8acJYbuo=",
-			"license": "APL 2.0",
-			"path": "github.com/smartystreets/assertions/internal/oglematchers",
-			"revision": "2063fd1cc7c975db70502811a34b06ad034ccdf2",
-			"revisionTime": "2016-07-07T19:03:55Z"
-		},
-		{
-			"checksumSHA1": "ZNcNGA0vNsM39HBFmM6JhHcdsLU=",
-			"comment": "FIXME(kormat): Use fork until https://github.com/smartystreets/goconvey/pull/451 is merged",
-			"license": "MIT",
-			"origin": "github.com/kormat/goconvey",
-			"path": "github.com/smartystreets/goconvey",
-			"revision": "a9793712606dd72b256bcbb0fad0858aa0e72d67",
-			"revisionTime": "2016-10-13T14:27:51Z",
-			"tree": true
-		},
-		{
 			"checksumSHA1": "g27xFm/EIghjjcT3DuGt976CgNo=",
 			"path": "github.com/walle/lll",
 			"revision": "8b13b3fbf7312913fcfdbfa78997b9bd1dbb11af",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -760,10 +760,22 @@
 			"revisionTime": "2018-06-07T13:59:11Z"
 		},
 		{
-			"checksumSHA1": "asZBHvcTKF5gVlI7AYnMlLXRYys=",
-			"path": "golang.org/x/crypto/sha3",
-			"revision": "b7391e95e576cacdcdd422573063bc057239113d",
-			"revisionTime": "2019-03-19T22:29:04Z"
+			"checksumSHA1": "CQYQ8wELyxPMRYOTDLELVtude/M=",
+			"path": "golang.org/x/image/font",
+			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
+			"revisionTime": "2019-03-12T13:36:53Z"
+		},
+		{
+			"checksumSHA1": "iV2FonJPeLV+iF4JHS3TRRXegF4=",
+			"path": "golang.org/x/image/font/basicfont",
+			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
+			"revisionTime": "2019-03-12T13:36:53Z"
+		},
+		{
+			"checksumSHA1": "euzvwlMLxyD0hwc+raoVsDLv6j4=",
+			"path": "golang.org/x/image/math/fixed",
+			"revision": "3fc05d484e9f77dd51816890e05f2602e4ca4d65",
+			"revisionTime": "2019-03-12T13:36:53Z"
 		},
 		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",


### PR DESCRIPTION
I had to add a different origin for the three roughtime.googlesource.com libraries, as
I could not make it work with govendor fetch or go get for the life of me.
Added roughtime to the makefile and fixed a missing call in the time server to use our scion util library.

The second commit comes from a patch from @mwfarb to add missing dependencies from `webapp`.

And while I was at it, I removed other unused entries so now `govendor list +o` returns empy.

Closes #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/60)
<!-- Reviewable:end -->
