### PR TITLE
Update webapp to use make's binary location

### DIFF
--- a/webapp/lib/config.go
+++ b/webapp/lib/config.go
@@ -13,8 +13,11 @@ import (
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
-// SCIONROOT is the root location on the scion infrastructure.
+// SCIONROOT is the root location of the scion infrastructure.
 var SCIONROOT = "src/github.com/scionproto/scion"
+
+// LABROOT is the root location of scionlab apps.
+var LABROOT = "src/github.com/netsec-ethz/scion-apps"
 
 // GOPATH is the root of the GOPATH environment.
 var GOPATH = os.Getenv("GOPATH")

--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -308,7 +308,7 @@ function manageTestData() {
                 if (d.graph != null) {
                     // write data on graph
                     for (var i = 0; i < d.graph.length; i++) {
-                        if (d.graph[i].Log != null) {
+                        if (d.graph[i].Log != null && d.graph[i].Log != "") {
                             // result returned, display it and reset progress
                             handleEndCmdDisplay(d.graph[i].Log);
                         }


### PR DESCRIPTION
Webapp should avoid using `$GOPATH/bin` for building/installing, and use the same locations built in `make`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/64)
<!-- Reviewable:end -->
