### PR TITLE
[shttp] Fixes a nil-pointer exception calling transport.Close()

### DIFF
--- a/lib/shttp/transport.go
+++ b/lib/shttp/transport.go
@@ -197,8 +197,11 @@ func unmangleSCIONAddr(host string) (addr.IA, addr.HostAddr, error) {
 }
 
 // Close closes the QUIC connections that this RoundTripper has used
-func (t *Transport) Close() error {
-	err := t.rt.Close()
+func (t *Transport) Close() (err error) {
+
+	if t.rt != nil {
+		err = t.rt.Close()
+	}
 
 	// quic.Session.Close (which is called by RoundTripper.Close()) will NOT
 	// close the underlying connections, so we do it manually here.


### PR DESCRIPTION
Fixes a nil-pointer exception when calling  transport.Close() where the underlying QUIC RoundTripper has not yet been initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/78)
<!-- Reviewable:end -->
