### PR TITLE
[webapp] Add Multi-Path Colors & bug fixes

### DIFF
--- a/webapp/lib/bwcont.go
+++ b/webapp/lib/bwcont.go
@@ -34,6 +34,7 @@ var reErr3 = `(?i:error:\s*)([\s\S]*)`
 var reErr4 = `(?i:eror:\s*)([\s\S]*)`
 var reErr5 = `(?i:crit:\s*)([\s\S]*)`
 var reUPath = `(?i:using path:)`
+var reSPath = `(?i:path=*)"(.*?)"`
 
 // ExtractBwtestRespData will parse cmd line output from bwtester for adding BwTestItem fields.
 func ExtractBwtestRespData(resp string, d *model.BwTestItem, start time.Time) {
@@ -91,7 +92,11 @@ func ExtractBwtestRespData(resp string, d *model.BwTestItem, start time.Time) {
 			data[dir]["arrival_max"] = re.FindStringSubmatch(r[i])[1]
 		}
 		// save used path (default or interactive) for later user display
-		if pathNext {
+		match, _ := regexp.MatchString(reSPath, r[i])
+		if match {
+			re := regexp.MustCompile(reSPath)
+			path = re.FindStringSubmatch(r[i])[1]
+		} else if pathNext {
 			path = strings.TrimSpace(r[i])
 		}
 		match, _ = regexp.MatchString(reUPath, r[i])

--- a/webapp/lib/echocont.go
+++ b/webapp/lib/echocont.go
@@ -76,23 +76,27 @@ func ExtractEchoRespData(resp string, d *model.EchoItem, start time.Time) {
 		match1, _ := regexp.MatchString(reErr1, r[i])
 		match2, _ := regexp.MatchString(reErr2, r[i])
 		match3, _ := regexp.MatchString(reErr3, r[i])
+		match4, _ := regexp.MatchString(reErr4, r[i])
+		match5, _ := regexp.MatchString(reErr5, r[i])
 
 		if match1 {
 			re := regexp.MustCompile(reErr1)
 			err = re.FindStringSubmatch(r[i])[1]
-			//log.Info("match1", "err", err)
 		} else if match2 {
 			re := regexp.MustCompile(reErr2)
 			err = re.FindStringSubmatch(r[i])[1]
 		} else if match3 {
 			re := regexp.MustCompile(reErr3)
 			err = re.FindStringSubmatch(r[i])[1]
+		} else if match4 {
+			re := regexp.MustCompile(reErr4)
+			err = re.FindStringSubmatch(r[i])[1]
+		} else if match5 {
+			re := regexp.MustCompile(reErr5)
+			err = re.FindStringSubmatch(r[i])[1]
 		}
 	}
 	log.Info("app response", "data", data)
-
-	//log.Info("print parsed result", "error", err)
-	//log.Info("print parsed result", "path", path)
 
 	d.RunTime, _ = data["run_time"]
 	d.ResponseTime, _ = data["response_time"]

--- a/webapp/static/css/style-viz.css
+++ b/webapp/static/css/style-viz.css
@@ -229,6 +229,9 @@ ul.tree li.open>ul {
 ul.tree li a {
  color: black;
  text-decoration: none;
+ padding-left: 5px; /* background shape */
+ padding-right: 5px; /* background shape */
+ border-radius: 10px; /* background shape */
 }
 
 ul.tree li a:before {

--- a/webapp/static/js/asviz.js
+++ b/webapp/static/js/asviz.js
@@ -49,12 +49,6 @@ function getTab() {
  * Creates on-click handler that will draw/hide selected path arcs.
  */
 function setupPathSelection() {
-    // add style to list of paths and segments
-    $('li[seg-type="CORE"]').children().css("color", colorSegCore);
-    $('li[seg-type="DOWN"]').children().css("color", colorSegDown);
-    $('li[seg-type="UP"]').children().css("color", colorSegUp);
-    $('li[seg-type="PATH"]').children().css("color", colorPaths);
-
     // handle path graph-only selection and color
     $("#as-iflist ul > li").click(function() {
         var type = $(this).attr("seg-type");

--- a/webapp/template/index.html
+++ b/webapp/template/index.html
@@ -332,6 +332,12 @@
         <div id="sc-bwtest-graph" class="chart"></div>
        </div>
 
+       <!-- IMAGE FETCHER LOADING -->
+       <div id="images" style="display: none;"></div>
+
+       <!-- SENSOR GRAPHING -->
+       <!-- nothing yet -->
+
        <!-- ECHO GRAPHING -->
        <div id="echo-continuous" style="display: none;">
         <div id="echo-graph" class="chart"></div>
@@ -387,7 +393,7 @@
     </div>
 
     <div id="as-iflist">
-     <h2>Selected Path Interfaces</h2>
+     <h2>Available Paths <span class='badge'>hops</span></h2>
      <input type="button" value="Update Paths" onclick="requestPaths();" />
      <p>
      <p id="path-info"></p>

--- a/webapp/template/index.html
+++ b/webapp/template/index.html
@@ -332,17 +332,12 @@
         <div id="sc-bwtest-graph" class="chart"></div>
        </div>
 
-       <!-- IMAGE FETCHER LOADING -->
-       <div id="images" style="display: none;"></div>
-
-       <!-- SENSOR GRAPHING -->
-       <!-- nothing yet -->
-
        <!-- ECHO GRAPHING -->
        <div id="echo-continuous" style="display: none;">
         <div id="echo-graph" class="chart"></div>
        </div>
 
+       <!-- COMMAND OUTPUT -->
        <div class="stdout">
         <div id="results"></div>
        </div>
@@ -393,7 +388,9 @@
     </div>
 
     <div id="as-iflist">
-     <h2>Available Paths <span class='badge'>hops</span></h2>
+     <h2>
+      Available Paths <span class='badge'>hops</span>
+     </h2>
      <input type="button" value="Update Paths" onclick="requestPaths();" />
      <p>
      <p id="path-info"></p>


### PR DESCRIPTION
- Adds deterministic colors for each unique path.
- Adds path colors to path selection list.
- Adds/changes path colors to bwtest and echo graph data points.
- Adds path # hops as a badge next to path selection list.
- Adds gray color for graph data points without matching paths.
- Changes to faint-red color for graph error data points, not red.
- Fixes bwtest failure to match interactive paths due to ANSI escapes.
- Fixes bwtest failure to match default path.
- Improves regex cases to record echo errors.
- Adds stderr to command parsing stream with stdout.
- Fixes overlapping continuous switch conditions between user-server.
- Fixes #69.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/81)
<!-- Reviewable:end -->
