### PR TITLE
[webapp] Full Local Topology Support and Multi-IA Selection

### DIFF
--- a/webapp/lib/config.go
+++ b/webapp/lib/config.go
@@ -1,15 +1,19 @@
 package lib
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
+	log "github.com/inconshreveable/log15"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
@@ -23,7 +27,6 @@ var LABROOT = "src/github.com/netsec-ethz/scion-apps"
 var GOPATH = os.Getenv("GOPATH")
 
 // default params for localhost testing
-var cliIaDef = "1-ff00:0:111"
 var serIaDef = "1-ff00:0:112"
 var cliPortDef = "30001"
 var serPortDefBwt = "30100"
@@ -36,18 +39,60 @@ var cfgFileSerUser = "config/servers_user.json"
 var cfgFileCliDef = "config/clients_default.json"
 var cfgFileSerDef = "config/servers_default.json"
 
-// GetLocalIa reads locally generated file for this IA's name, if written
-func GetLocalIa() string {
-	filepath := path.Join(GOPATH, SCIONROOT, "gen/ia")
-	b, err := ioutil.ReadFile(filepath)
-	if CheckError(err) {
-		return ""
-	}
-	return strings.Replace(strings.TrimSpace(string(b)), "_", ":", -1)
+// UserSetting holds the serialized structure for persistent user settings
+type UserSetting struct {
+	MyIA string `json:"myIa"`
 }
 
-func GetCliIaDef() string {
-	return cliIaDef
+// WriteClientsUser writes the settings to disk.
+func WriteClientsUser(srcpath string, settings UserSetting) {
+	settings.MyIA = strings.Replace(settings.MyIA, "_", ":", -1)
+	cliUserFp := path.Join(srcpath, cfgFileCliUser)
+	settingsJSON, _ := json.Marshal(settings)
+
+	err := ioutil.WriteFile(cliUserFp, settingsJSON, 0644)
+	CheckError(err)
+}
+
+// ReadClientsUser reads the settings from disk.
+func ReadClientsUser(srcpath string) UserSetting {
+	var settings UserSetting
+	cliUserFp := path.Join(srcpath, cfgFileCliUser)
+
+	// no problem when user settings not set yet
+	raw, err := ioutil.ReadFile(cliUserFp)
+	log.Debug("ReadClientsUser", "settings", string(raw))
+	if err != nil {
+		json.Unmarshal([]byte(raw), &settings)
+	}
+	settings.MyIA = strings.Replace(settings.MyIA, "_", ":", -1)
+	return settings
+}
+
+// ScanLocalIAs will load list of locally available IAs
+func ScanLocalIAs() []string {
+	var localIAs []string
+	var reIaFilePathDir = `\/ISD[0-9]+\/AS\w+$`
+	var reIaFilePathCap = `\/ISD([0-9]+)\/AS(\w+)`
+	var searchPath = path.Join(GOPATH, SCIONROOT, "gen")
+	filepath.Walk(searchPath, func(path string, f os.FileInfo, _ error) error {
+		if f.IsDir() {
+			match, _ := regexp.MatchString(reIaFilePathDir, path)
+			if match {
+				match, _ := regexp.MatchString(reIaFilePathCap, path)
+				if match {
+					re := regexp.MustCompile(reIaFilePathCap)
+					capture := re.FindStringSubmatch(path)
+					ia := capture[1] + "-" + capture[2]
+					log.Debug("Local IA Found:", "ia", ia)
+					localIAs = append(localIAs, ia)
+				}
+			}
+		}
+		return nil
+	})
+	sort.Strings(localIAs)
+	return localIAs
 }
 
 // Makes interfaces sortable, by preferred name
@@ -87,36 +132,31 @@ func (c byPrefInterface) Less(i, j int) bool {
 }
 
 // GenServerNodeDefaults creates server defaults for localhost testing
-func GenServerNodeDefaults(srcpath string) {
-	serFp := path.Join(srcpath, cfgFileSerUser)
-	jsonBuf := []byte(`{ `)
-	json := []byte(`"bwtester": [{"name":"lo ` + serIaDef + `","isdas":"` +
-		serIaDef + `", "addr":"` + serDefAddr + `","port":` + serPortDefBwt +
-		`},{"name":"lo 2-ff00:0:222","isdas":"2-ff00:0:222", "addr":"127.0.0.22","port":30101}], `)
-	jsonBuf = append(jsonBuf, json...)
-	json = []byte(`"camerapp": [{"name":"localhost","isdas":"` +
-		serIaDef + `", "addr":"` + serDefAddr + `","port":` + serPortDefImg + `}], `)
-	jsonBuf = append(jsonBuf, json...)
-	json = []byte(`"sensorapp": [{"name":"localhost","isdas":"` +
-		serIaDef + `", "addr":"` + serDefAddr + `","port":` + serPortDefSen + `}], `)
-	jsonBuf = append(jsonBuf, json...)
-	json = []byte(`"echo": [{"name":"localhost","isdas":"` +
-		serIaDef + `", "addr":"` + serDefAddr + `","port":` + serPortDefSen + `}]`)
-	jsonBuf = append(jsonBuf, json...)
+func GenServerNodeDefaults(srcpath string, localIAs []string) {
+	// reverse sort so that the default server will oppose the default client
+	sort.Sort(sort.Reverse(sort.StringSlice(localIAs)))
 
-	jsonBuf = append(jsonBuf, []byte(` }`)...)
+	serFp := path.Join(srcpath, cfgFileSerUser)
+	jsonBuf := []byte(`{ "all": [`)
+	for i := 0; i < len(localIAs); i++ {
+		// use all localhost endpoints as possible servers for bwtester as least
+		ia := strings.Replace(localIAs[i], "_", ":", -1)
+		json := []byte(`{"name":"lo ` + ia + `","isdas":"` + ia +
+			`", "addr":"` + serDefAddr + `","port":` + serPortDefBwt + `}`)
+		jsonBuf = append(jsonBuf, json...)
+		if i < (len(localIAs) - 1) {
+			jsonBuf = append(jsonBuf, []byte(`,`)...)
+		}
+	}
+	jsonBuf = append(jsonBuf, []byte(`] }`)...)
 	err := ioutil.WriteFile(serFp, jsonBuf, 0644)
 	CheckError(err)
 }
 
 // GenClientNodeDefaults queries network interfaces and writes local client
 // SCION addresses as json
-func GenClientNodeDefaults(srcpath string) {
+func GenClientNodeDefaults(srcpath, cisdas string) {
 	cliFp := path.Join(srcpath, cfgFileCliDef)
-	cisdas := GetLocalIa()
-	if len(cisdas) == 0 {
-		cisdas = cliIaDef
-	}
 	cport := cliPortDef
 
 	// find interface addresses

--- a/webapp/lib/config.go
+++ b/webapp/lib/config.go
@@ -71,13 +71,12 @@ func ReadUserSetting(srcpath string) UserSetting {
 func ScanLocalIAs() []string {
 	var localIAs []string
 	var reIaFilePathCap = `\/ISD([0-9]+)\/AS(\w+)`
+	re := regexp.MustCompile(reIaFilePathCap)
 	var searchPath = path.Join(GOPATH, SCIONROOT, "gen")
 	filepath.Walk(searchPath, func(path string, f os.FileInfo, _ error) error {
 		if f != nil && f.IsDir() {
-			match, _ := regexp.MatchString(reIaFilePathCap, path)
-			if match {
-				re := regexp.MustCompile(reIaFilePathCap)
-				capture := re.FindStringSubmatch(path)
+			capture := re.FindStringSubmatch(path)
+			if len(capture) > 0 {
 				ia := capture[1] + "-" + capture[2]
 				ia = strings.Replace(ia, "_", ":", -1) // convert once
 				if !StringInSlice(localIAs, ia) {

--- a/webapp/lib/health.go
+++ b/webapp/lib/health.go
@@ -44,7 +44,7 @@ type ResHealthCheck struct {
 
 // HealthCheckHandler handles calling the default health-check scripts and
 // returning the json-formatted results of each script.
-func HealthCheckHandler(w http.ResponseWriter, r *http.Request, srcpath string) {
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request, srcpath string, ia string) {
 	hcResFp := path.Join(srcpath, resFileHealthCheck)
 	// read specified tests from json definition
 	fp := path.Join(srcpath, defFileHealthCheck)
@@ -78,7 +78,7 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request, srcpath string) 
 		pass := true
 		log.Info(test.Script + ": " + test.Desc)
 		// execute script
-		cmd := exec.Command("bash", test.Script)
+		cmd := exec.Command("bash", test.Script, ia)
 		cmd.Dir = filepath.Dir(fp)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout

--- a/webapp/lib/sciond.go
+++ b/webapp/lib/sciond.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -38,20 +39,46 @@ func returnError(w http.ResponseWriter, err error) {
 	fmt.Fprintf(w, `{"err":`+strconv.Quote(err.Error())+`}`)
 }
 
-func returnPathHandler(w http.ResponseWriter, pathJson []byte, segJson []byte, err error) {
+func returnPathHandler(w http.ResponseWriter, pathJSON []byte, segJSON []byte, err error) {
 	var buffer bytes.Buffer
 	buffer.WriteString(`{"src":"sciond"`)
-	if pathJson != nil {
-		buffer.WriteString(fmt.Sprintf(`,"paths":%s`, pathJson))
+	if pathJSON != nil {
+		buffer.WriteString(fmt.Sprintf(`,"paths":%s`, pathJSON))
 	}
-	if segJson != nil {
-		buffer.WriteString(fmt.Sprintf(`,"segments":%s`, segJson))
+	if segJSON != nil {
+		buffer.WriteString(fmt.Sprintf(`,"segments":%s`, segJSON))
 	}
 	if err != nil {
 		buffer.WriteString(fmt.Sprintf(`,"err":%s`, strconv.Quote(err.Error())))
 	}
 	buffer.WriteString(`}`)
 	fmt.Fprintf(w, buffer.String())
+}
+
+func getNetworkByIA(iaCli string) (*snet.SCIONNetwork, error) {
+	ia, err := addr.IAFromString(iaCli)
+	if CheckError(err) {
+		return nil, err
+	}
+	dispatcherPath := "/run/shm/dispatcher/default.sock"
+	var sciondPath string
+	isdCli, _ := strconv.Atoi(strings.Split(iaCli, "-")[0])
+	if isdCli < 16 {
+		sciondPath = sciond.GetDefaultSCIONDPath(&ia)
+	} else {
+		sciondPath = sciond.GetDefaultSCIONDPath(nil)
+	}
+	if snet.DefNetwork == nil {
+		err := snet.Init(ia, sciondPath, dispatcherPath)
+		if CheckError(err) {
+			return nil, err
+		}
+	}
+	network, err := snet.NewNetwork(ia, sciondPath, dispatcherPath)
+	if CheckError(err) {
+		return nil, err
+	}
+	return network, nil
 }
 
 // sciond data sources and calls
@@ -76,25 +103,13 @@ func PathTopoHandler(w http.ResponseWriter, r *http.Request) {
 	clientCCAddr, _ := snet.AddrFromString(optClient)
 	serverCCAddr, _ := snet.AddrFromString(optServer)
 
-	if snet.DefNetwork == nil {
-		dispatcherPath := "/run/shm/dispatcher/default.sock"
-
-		var sciondPath string
-		isdCli, _ := strconv.Atoi(strings.Split(CIa, "-")[0])
-		if isdCli < 16 {
-			sciondPath = sciond.GetDefaultSCIONDPath(&clientCCAddr.IA)
-		} else {
-			sciondPath = sciond.GetDefaultSCIONDPath(nil)
-		}
-
-		err := snet.Init(clientCCAddr.IA, sciondPath, dispatcherPath)
-		if CheckError(err) {
-			returnError(w, err)
-			return
-		}
+	network, err := getNetworkByIA(CIa)
+	if CheckError(err) {
+		returnError(w, err)
+		return
 	}
 
-	paths, err := getPathsJSON(*clientCCAddr, *serverCCAddr)
+	paths, err := getPathsJSON(*clientCCAddr, *serverCCAddr, *network)
 	if CheckError(err) {
 		returnError(w, err)
 		return
@@ -138,6 +153,16 @@ func getSegmentsJSON(local snet.Addr) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	sort.Slice(segments, func(i, j int) bool {
+		// sort by segment type, then shortest # hops
+		if segments[i].SegType < segments[j].SegType {
+			return true
+		}
+		if segments[i].SegType > segments[j].SegType {
+			return false
+		}
+		return len(segments[i].Interfaces) < len(segments[j].Interfaces)
+	})
 	jsonSegsInfo, err := json.Marshal(segments)
 	if err != nil {
 		return nil, err
@@ -196,8 +221,8 @@ func removeAllDir(dirName string) {
 	CheckError(err)
 }
 
-func getPathsJSON(local snet.Addr, remote snet.Addr) ([]byte, error) {
-	pathMgr := snet.DefNetwork.PathResolver()
+func getPathsJSON(local snet.Addr, remote snet.Addr, network snet.SCIONNetwork) ([]byte, error) {
+	pathMgr := network.PathResolver()
 	pathSet := pathMgr.Query(context.Background(), local.IA, remote.IA)
 	if len(pathSet) == 0 {
 		return nil, fmt.Errorf("No paths from %s to %s", local.IA, remote.IA)
@@ -206,6 +231,16 @@ func getPathsJSON(local snet.Addr, remote snet.Addr) ([]byte, error) {
 	for _, path := range pathSet {
 		appPaths = append(appPaths, path)
 	}
+	sort.Slice(appPaths, func(i, j int) bool {
+		// sort by shortest # hops, then by IA/interface
+		if len(appPaths[i].Entry.Path.Interfaces) < len(appPaths[j].Entry.Path.Interfaces) {
+			return true
+		}
+		if len(appPaths[i].Entry.Path.Interfaces) > len(appPaths[j].Entry.Path.Interfaces) {
+			return false
+		}
+		return appPaths[i].Entry.String() < appPaths[j].Entry.String()
+	})
 	jsonPathInfo, err := json.Marshal(appPaths)
 	if err != nil {
 		return nil, err
@@ -217,30 +252,13 @@ func getPathsJSON(local snet.Addr, remote snet.Addr) ([]byte, error) {
 func AsTopoHandler(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	CIa := r.PostFormValue("src")
-	ia, err := addr.IAFromString(CIa)
+
+	network, err := getNetworkByIA(CIa)
 	if CheckError(err) {
 		returnError(w, err)
 		return
 	}
-	if snet.DefNetwork == nil {
-		dispatcherPath := "/run/shm/dispatcher/default.sock"
-
-		var sciondPath string
-		isdCli, _ := strconv.Atoi(strings.Split(CIa, "-")[0])
-		if isdCli < 16 {
-			sciondPath = sciond.GetDefaultSCIONDPath(&ia)
-		} else {
-			sciondPath = sciond.GetDefaultSCIONDPath(nil)
-		}
-
-		err := snet.Init(ia, sciondPath, dispatcherPath)
-		if CheckError(err) {
-			returnError(w, err)
-			return
-		}
-	}
-
-	c := snet.DefNetwork.Sciond()
+	c := network.Sciond()
 
 	asir, err := c.ASInfo(context.Background(), addr.IA{})
 	if CheckError(err) {

--- a/webapp/lib/sciond.go
+++ b/webapp/lib/sciond.go
@@ -18,11 +18,11 @@ import (
 	"strings"
 
 	log "github.com/inconshreveable/log15"
+	"github.com/netsec-ethz/scion-apps/lib/scionutil"
 	pathdb "github.com/netsec-ethz/scion-apps/webapp/models/path"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/spath/spathmeta"
 	"github.com/scionproto/scion/go/proto"
@@ -61,13 +61,7 @@ func getNetworkByIA(iaCli string) (*snet.SCIONNetwork, error) {
 		return nil, err
 	}
 	dispatcherPath := "/run/shm/dispatcher/default.sock"
-	var sciondPath string
-	isdCli, _ := strconv.Atoi(strings.Split(iaCli, "-")[0])
-	if isdCli < 16 {
-		sciondPath = sciond.GetDefaultSCIONDPath(&ia)
-	} else {
-		sciondPath = sciond.GetDefaultSCIONDPath(nil)
-	}
+	sciondPath := scionutil.GetSCIONDPath(&ia)
 	if snet.DefNetwork == nil {
 		err := snet.Init(ia, sciondPath, dispatcherPath)
 		if CheckError(err) {

--- a/webapp/models/path/db.go
+++ b/webapp/models/path/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 )
 
+// InitDB controls the opening connection to the database.
 func InitDB(filepath string) (*sql.DB, error) {
 	//var err error
 	db, err := sql.Open("sqlite3", filepath+"?mode=ro")
@@ -17,6 +18,7 @@ func InitDB(filepath string) (*sql.DB, error) {
 	return db, nil
 }
 
+// CloseDB will close the database, only use when app closes.
 func CloseDB(db *sql.DB) error {
 	err := db.Close()
 	return err

--- a/webapp/models/path/segments.go
+++ b/webapp/models/path/segments.go
@@ -56,7 +56,7 @@ func newSegment(segType proto.PathSegType, srcI addr.ISD, srcA addr.AS, dstI add
 		Interfaces: interfaces, Updated: time.Unix(0, updateTime), Expiry: time.Unix(expiryTime, 0)}
 }
 
-// ReadSegTypesAll operates on the DB to return all SegTyoe rows.
+// ReadSegTypesAll operates on the DB to return all SegType rows.
 func ReadSegTypesAll(db *sql.DB) (map[int64]proto.PathSegType, error) {
 	sqlReadAll := `
     SELECT

--- a/webapp/models/path/segments.go
+++ b/webapp/models/path/segments.go
@@ -56,6 +56,7 @@ func newSegment(segType proto.PathSegType, srcI addr.ISD, srcA addr.AS, dstI add
 		Interfaces: interfaces, Updated: time.Unix(0, updateTime), Expiry: time.Unix(expiryTime, 0)}
 }
 
+// ReadSegTypesAll operates on the DB to return all SegTyoe rows.
 func ReadSegTypesAll(db *sql.DB) (map[int64]proto.PathSegType, error) {
 	sqlReadAll := `
     SELECT
@@ -84,6 +85,7 @@ func ReadSegTypesAll(db *sql.DB) (map[int64]proto.PathSegType, error) {
 	return result, nil
 }
 
+// ReadIntfToSegAll operates on the DB to return all IntfToSeg rows.
 func ReadIntfToSegAll(db *sql.DB) (map[int64][]asIface, error) {
 	sqlReadAll := `
     SELECT
@@ -118,6 +120,7 @@ func ReadIntfToSegAll(db *sql.DB) (map[int64][]asIface, error) {
 	return result, nil
 }
 
+// ReadSegmentsAll operates on the DB to return all Segments rows.
 func ReadSegmentsAll(db *sql.DB, segTypes map[int64]proto.PathSegType) ([]segment, error) {
 	sqlReadAll := `
     SELECT

--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -843,12 +843,14 @@ function updateNode(node) {
                 .attr('name');
         var app_nodes = nodes[node][activeApp];
         var sel = $('#sel_' + node).find("option:selected").attr('value');
-        $('#ia_' + node).val(app_nodes[sel].isdas.replace(/_/g, ":"));
-        $('#addr_' + node).val(app_nodes[sel].addr);
-        $('#port_' + node).val(app_nodes[sel].port);
-        if (node == 'ser') {
-            // server node change complete, update paths
-            requestPaths();
+        if (sel != null) {
+            $('#ia_' + node).val(app_nodes[sel].isdas.replace(/_/g, ":"));
+            $('#addr_' + node).val(app_nodes[sel].addr);
+            $('#port_' + node).val(app_nodes[sel].port);
+            if (node == 'ser') {
+                // server node change complete, update paths
+                requestPaths();
+            }
         }
     }
 }

--- a/webapp/static/js/webapp.js
+++ b/webapp/static/js/webapp.js
@@ -785,8 +785,6 @@ function initNodes() {
     });
     $('#sel_ser').change(function() {
         updateNode('ser');
-        // server node change complete, update paths
-        requestPaths();
     });
 }
 
@@ -814,9 +812,6 @@ function loadNodes(node, list) {
             if (node == 'cli') {
                 // after client selection, update server options
                 loadServerNodes();
-            } else {
-                // server node change complete, update paths
-                requestPaths();
             }
         } else {
             console.error("Error: " + jqXHR.status + ": " + jqXHR.statusText);
@@ -825,8 +820,9 @@ function loadNodes(node, list) {
 }
 
 function updateNodeOptions(node) {
-    var activeApp = (node == 'cli') ? 'all' : $('.nav-tabs .active > a').attr(
-            'name');
+    var allNode = nodes[node]['all'];
+    var activeApp = (allNode != null) ? 'all' : $('.nav-tabs .active > a')
+            .attr('name');
     console.debug(activeApp);
     var app_nodes = nodes[node][activeApp];
     $('#sel_' + node).empty();
@@ -842,13 +838,18 @@ function updateNodeOptions(node) {
 function updateNode(node) {
     // populate fields
     if (nodes[node]) {
-        var activeApp = (node == 'cli') ? 'all' : $('.nav-tabs .active > a')
+        var allNode = nodes[node]['all'];
+        var activeApp = (allNode != null) ? 'all' : $('.nav-tabs .active > a')
                 .attr('name');
         var app_nodes = nodes[node][activeApp];
         var sel = $('#sel_' + node).find("option:selected").attr('value');
         $('#ia_' + node).val(app_nodes[sel].isdas.replace(/_/g, ":"));
         $('#addr_' + node).val(app_nodes[sel].addr);
         $('#port_' + node).val(app_nodes[sel].port);
+        if (node == 'ser') {
+            // server node change complete, update paths
+            requestPaths();
+        }
     }
 }
 

--- a/webapp/template/header.html
+++ b/webapp/template/header.html
@@ -67,20 +67,21 @@ body {
 
                 // on document load, request full list of available IAs
                 var ias = JSON.parse(data);
-                ias.sort();
-                for (i in ias) {
-                    var ia_str = ias[i].replace(/_/g, ":");
-                    var a = $('<a/>', {
-                        name : ias[i],
-                        href : '#',
-                        html : ia_str
-                    });
-                    var li = $('<li/>');
-                    li.append(a);
-                    var ul = $('#ia-dropdown-menu');
-                    ul.append(li);
+                if (ias != null) {
+                    ias.sort();
+                    for (i in ias) {
+                        var ia_str = ias[i];
+                        var a = $('<a/>', {
+                            name : ias[i],
+                            href : '#',
+                            html : ia_str
+                        });
+                        var li = $('<li/>');
+                        li.append(a);
+                        var ul = $('#ia-dropdown-menu');
+                        ul.append(li);
+                    }
                 }
-
                 // after IA list is populated, and after window load, attach clicks
 
                 // set click handler only after list populated

--- a/webapp/template/header.html
+++ b/webapp/template/header.html
@@ -36,10 +36,17 @@ body {
      <span class="icon-bar"></span> <span class="icon-bar"></span> <span
       class="icon-bar"></span>
     </button>
-    <a class="navbar-brand" href="#">SCIONLab {{.MyIA}}</a>
+    <a class="navbar-brand" href="#">SCIONLab</a>
    </div>
    <div class="navbar-inverse collapse navbar-collapse" id="myNavbar">
     <ul class="nav navbar-nav navbar-left">
+     <li id="nav-srcia" class="dropdown"><a id="ia-selected"
+      class="dropdown-toggle" data-toggle="dropdown" href="#">{{.MyIA}}
+       <span class="caret"></span>
+     </a>
+      <ul id="ia-dropdown-menu" class="dropdown-menu">
+       <!-- server will populate list with available IAs -->
+      </ul>
      <li><a id="nav-health" href="/">Health</a></li>
      <li><a id="nav-apps" href="/apps">Apps</a></li>
      <!--<li><a id="nav-files" href="/dirview">Files</a></li> -->
@@ -52,4 +59,50 @@ body {
    </div>
   </div>
  </nav>
+
+ <script type="text/javascript">
+        $(window).on("load", function() {
+            $.post("/getias", function(data) {
+                console.info(data);
+
+                // on document load, request full list of available IAs
+                var ias = JSON.parse(data);
+                ias.sort();
+                for (i in ias) {
+                    var ia_str = ias[i].replace(/_/g, ":");
+                    var a = $('<a/>', {
+                        name : ias[i],
+                        href : '#',
+                        html : ia_str
+                    });
+                    var li = $('<li/>');
+                    li.append(a);
+                    var ul = $('#ia-dropdown-menu');
+                    ul.append(li);
+                }
+
+                // after IA list is populated, and after window load, attach clicks
+
+                // set click handler only after list populated
+                $('.dropdown-menu a').click(function(e) {
+                    // handle nav-srcia selection
+                    var a = $('#ia-selected');
+                    a.text($(this).text());
+                    a.append(' <span class="caret"></span>');
+
+                    // log chosen IA
+                    console.warn("ia choice:", e.target.name);
+                    var data = {
+                        myIA : e.target.text
+                    };
+                    // set chosen IA in server
+                    $.post("/setuseropt", data, function(json) {
+                        // reload this page, no cache
+                        location.reload(true);
+                    });
+                });
+            });
+        });
+    </script>
+
  {{end}}

--- a/webapp/template/header.html
+++ b/webapp/template/header.html
@@ -67,7 +67,7 @@ body {
 
                 // on document load, request full list of available IAs
                 var ias = JSON.parse(data);
-                if (ias != null) {
+                if (ias != null && ias.length > 0) {
                     ias.sort();
                     for (i in ias) {
                         var ia_str = ias[i];
@@ -81,6 +81,8 @@ body {
                         var ul = $('#ia-dropdown-menu');
                         ul.append(li);
                     }
+                } else {
+                    showError('Local IA not found. Is SCION installed?');
                 }
                 // after IA list is populated, and after window load, attach clicks
 

--- a/webapp/template/index.html
+++ b/webapp/template/index.html
@@ -36,7 +36,7 @@
      <div id="in-client" class="scion-ia">
       <span>Source</span><br> <select name="sel_cli" id="sel_cli"
        style="width: 120px;"></select><br>IA: <input type="text"
-       name="ia_cli" id="ia_cli" required placeholder="1-11"
+       name="ia_cli" id="ia_cli" required placeholder="1-ff00:0:111"
        pattern="^[0-9]+-[0-9a-fA-F_:\/]+$" style="width: 120px;"><br>Host:
       <input type="text" name="addr_cli" id="addr_cli" required
        placeholder="127.0.0.3"
@@ -279,10 +279,10 @@
      <div id="in-server" class="scion-ia">
       <span>Destination</span><br> <select name="sel_ser"
        id="sel_ser" style="width: 120px;"></select><br>IA: <input
-       type="text" name="ia_ser" id="ia_ser" required placeholder="1-12"
-       pattern="^[0-9]+-[0-9a-fA-F_:\/]+$" style="width: 120px;">
-      <br>Host: <input type="text" name="addr_ser" id="addr_ser"
-       required placeholder="127.0.0.2"
+       type="text" name="ia_ser" id="ia_ser" required
+       placeholder="1-ff00:0:112" pattern="^[0-9]+-[0-9a-fA-F_:\/]+$"
+       style="width: 120px;"> <br>Host: <input type="text"
+       name="addr_ser" id="addr_ser" required placeholder="127.0.0.2"
        pattern="((^|\.)((25[0-5])|(2[0-4]\d)|(1\d\d)|([1-9]?\d))){4}$"
        style="width: 125px;"> <br>Port: <input
        name="port_ser" id="port_ser" type="number" required

--- a/webapp/tests/health/beaconstest.sh
+++ b/webapp/tests/health/beaconstest.sh
@@ -8,9 +8,8 @@ timeout_ms=20000
 pcb_ms=10000
 
 # allow IA via args, ignoring gen/ia
-ia=$(echo $1 | sed "s/_/:/g")
 iaFile=$(echo $1 | sed "s/:/_/g")
-echo "IA found: $ia"
+echo "IA found: $iaFile"
 
 # format log file and beacons grep string
 logfile=~/go/src/github.com/scionproto/scion/logs/bs${iaFile}-1.DEBUG

--- a/webapp/tests/health/beaconstest.sh
+++ b/webapp/tests/health/beaconstest.sh
@@ -7,9 +7,9 @@ timeout_ms=20000
 # oldest accept age of last PCB
 pcb_ms=10000
 
-# get local IA
-iaFile=$(cat ~/go/src/github.com/scionproto/scion/gen/ia)
-ia=$(echo $iaFile | sed "s/_/:/g")
+# allow IA via args, ignoring gen/ia
+ia=$(echo $1 | sed "s/_/:/g")
+iaFile=$(echo $1 | sed "s/:/_/g")
 echo "IA found: $ia"
 
 # format log file and beacons grep string

--- a/webapp/tests/health/netcheck.sh
+++ b/webapp/tests/health/netcheck.sh
@@ -2,9 +2,8 @@
 # test will fail for non-zero exit and/or bytes in stderr
 
 # allow IA via args, ignoring gen/ia
-ia=$(echo $1 | sed "s/_/:/g")
 iaFile=$(echo $1 | sed "s/:/_/g")
-echo "IA found: $ia"
+echo "IA found: $iaFile"
 
 isd=$(echo ${iaFile} | cut -d"-" -f1)
 as=$(echo ${iaFile} | cut -d"-" -f2)

--- a/webapp/tests/health/netcheck.sh
+++ b/webapp/tests/health/netcheck.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # test will fail for non-zero exit and/or bytes in stderr
 
-# get local IA
-iaFile=$(cat ~/go/src/github.com/scionproto/scion/gen/ia)
-ia=$(echo $iaFile | sed "s/_/:/g")
+# allow IA via args, ignoring gen/ia
+ia=$(echo $1 | sed "s/_/:/g")
+iaFile=$(echo $1 | sed "s/:/_/g")
 echo "IA found: $ia"
 
 isd=$(echo ${iaFile} | cut -d"-" -f1)

--- a/webapp/tests/health/scmpcheck.sh
+++ b/webapp/tests/health/scmpcheck.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # test will fail for non-zero exit and/or bytes in stderr
 
-# get local IA
-iaFile=$(cat ~/go/src/github.com/scionproto/scion/gen/ia)
-ia=$(echo $iaFile | sed "s/_/:/g")
+# allow IA via args, ignoring gen/ia
+ia=$(echo $1 | sed "s/_/:/g")
+iaFile=$(echo $1 | sed "s/:/_/g")
 echo "IA found: $ia"
 
 # get local IP

--- a/webapp/tests/health/scmpcheck.sh
+++ b/webapp/tests/health/scmpcheck.sh
@@ -4,7 +4,7 @@
 # allow IA via args, ignoring gen/ia
 ia=$(echo $1 | sed "s/_/:/g")
 iaFile=$(echo $1 | sed "s/:/_/g")
-echo "IA found: $ia"
+echo "IA found: $iaFile"
 
 # get local IP
 ip=$(hostname -I | cut -d" " -f1)

--- a/webapp/tests/health/testSCIONRunning.sh
+++ b/webapp/tests/health/testSCIONRunning.sh
@@ -53,13 +53,16 @@ else
 fi
 }
 
-# get local IA
-iaFile=$(cat $SC/gen/ia)
+# allow IA via args, ignoring gen/ia
+ia=$(echo $1 | sed "s/_/:/g")
+iaFile=$(echo $1 | sed "s/:/_/g")
+echo "IA found: $ia"
+
 isd=$(echo ${iaFile} | cut -d"-" -f1)
 
-check_presence $SC/gen ia
 if [ $isd -ge 16 ]; then
     # not used for localhost testing
+    check_presence $SC/gen ia
     check_presence /run/shm/sciond default.sock
 fi
 check_presence /run/shm/dispatcher default.sock

--- a/webapp/tests/health/testSCIONRunning.sh
+++ b/webapp/tests/health/testSCIONRunning.sh
@@ -54,9 +54,8 @@ fi
 }
 
 # allow IA via args, ignoring gen/ia
-ia=$(echo $1 | sed "s/_/:/g")
 iaFile=$(echo $1 | sed "s/:/_/g")
-echo "IA found: $ia"
+echo "IA found: $iaFile"
 
 isd=$(echo ${iaFile} | cut -d"-" -f1)
 

--- a/webapp/util/log.go
+++ b/webapp/util/log.go
@@ -4,24 +4,26 @@ import (
 	log "github.com/inconshreveable/log15"
 )
 
+// CheckError handles Error logging
 func CheckError(e error) bool {
 	if e != nil {
-		LogError("Error:", "err", e)
+		logError("Error:", "err", e)
 	}
 	return e != nil
 }
 
+// CheckFatal handles Fatal logging
 func CheckFatal(e error) bool {
 	if e != nil {
-		LogFatal("Fatal:", "err", e)
+		logFatal("Fatal:", "err", e)
 	}
 	return e != nil
 }
 
-func LogError(msg string, a ...interface{}) {
+func logError(msg string, a ...interface{}) {
 	log.Error(msg, a...)
 }
 
-func LogFatal(msg string, a ...interface{}) {
+func logFatal(msg string, a ...interface{}) {
 	log.Crit(msg, a...)
 }


### PR DESCRIPTION
- Removed use of gen/ia
- Scans local gen dir endhosts for all local IAs
- Allows local topology user to switch src IAs from nav bar.
- Allows local topology user to switch dest IAs from bwtest server.
- Saves src IA selection in persistent  user setting.
- Updates health checks to ignore gen/ia, using nav bar selection.
- Sorts paths tree list consistently by # hops.
- Adds full reverse-sorted list of server localhost IAs.
- Minor Go linting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/84)
<!-- Reviewable:end -->
