### PR TITLE
Allow setting custom output path for imagefetcher

### DIFF
--- a/camerapp/imagefetcher/imagefetcher.go
+++ b/camerapp/imagefetcher/imagefetcher.go
@@ -165,6 +165,7 @@ func main() {
 		sciondPath     string
 		sciondFromIA   bool
 		dispatcherPath string
+		outputFilePath string
 
 		err    error
 		local  *snet.Addr
@@ -179,6 +180,7 @@ func main() {
 	flag.BoolVar(&sciondFromIA, "sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
 	flag.StringVar(&dispatcherPath, "dispatcher", "/run/shm/dispatcher/default.sock",
 		"Path to dispatcher socket")
+	flag.StringVar(&outputFilePath, "output", "", "Path to the output file")
 	flag.Parse()
 
 	// Create SCION UDP socket
@@ -280,7 +282,10 @@ func main() {
 	}
 
 	// Write file to disk
-	err = ioutil.WriteFile(fileName, fileBuffer, 0600)
+	if outputFilePath == "" {
+		outputFilePath = fileName
+	}
+	err = ioutil.WriteFile(outputFilePath, fileBuffer, 0600)
 	check(err)
 	fmt.Println("\nDone, exiting. Total duration", time.Now().Sub(startTime))
 }


### PR DESCRIPTION
As an operator I want to be able to set an arbitrary path for the output file returned by the server.

Closes-Bug: #90

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/92)
<!-- Reviewable:end -->
