### PR TITLE
 Cleanup Makefile, build out-of-source into bin/ dir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ webapp/web/data
 vendor/*/
 
 # generated binaries
+bin/
 bat/bat
 bwtester/bwtestclient/bwtestclient
 bwtester/bwtestserver/bwtestserver

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test: lint
 
 setup_lint:
 	@# Install golangci-lint (as dumb as this looks, this is the recommended way to install)
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $$(go env GOPATH)/bin v1.23.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $$(go env GOPATH)/bin v1.26.0
 
 lint:
 	@type golangci-lint > /dev/null || ( echo "golangci-lint not found. Install it manually or by running 'make setup_lint'."; exit 1 )

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,23 @@
 .PHONY: all clean test lint build install
 
-ROOT_DIR=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-SRCDIRS= sensorapp/sensorserver sensorapp/sensorfetcher camerapp/imageserver camerapp/imagefetcher bwtester/bwtestserver bwtester/bwtestclient bat ssh/client ssh/server netcat webapp _examples/helloworld _examples/shttp/client _examples/shttp/server
-BUILD_TARGETS = $(foreach D,$(SRCDIRS),$(D)/$(notdir $(D)))
+BIN = bin
+# default DESTDIR for installation uses fallback sequence, as documented by go install.
+DESTDIR = $(shell go env GOBIN GOPATH | eval; echo $${GOBIN:-$${GOPATH:-$${HOME}/go}/bin})
 
 all: lint build
 
+build: scion-bat \
+	scion-bwtestclient scion-bwtestserver \
+	scion-imagefetcher scion-imageserver \
+	scion-netcat \
+	scion-sensorfetcher scion-sensorserver \
+	scion-sshd scion-sshd \
+	example-helloworld \
+	example-shttp-client example-shttp-server
+
 clean:
 	go clean ./...
+	rm -f bin/*
 
 test: lint
 	go test -v ./...
@@ -20,19 +30,66 @@ lint:
 	@type golangci-lint > /dev/null || ( echo "golangci-lint not found. Install it manually or by running 'make setup_lint'."; exit 1 )
 	golangci-lint run
 
-build: $(BUILD_TARGETS)
-
 install: all
-	@$(foreach d,$(SRCDIRS), cd $(ROOT_DIR)/$(d); cp $(shell basename $(d)) /go/bin;)
+  # Note: install everything but the examples
+	mkdir -p $(DESTDIR)
+	cp -t $(DESTDIR) $(BIN)/scion-*
 
-integration: install
-	go test -v -tags=integration ./...
+integration: all
+	go test -v -tags=integration ./... ./_examples/helloworld/
 
-# using eval to create as many rules as we have $BUILD_TARGETS
-# each target corresponds to the binary file name (e.g. sensorapp/sensorserver/sensorserver)
-define gobuild_tmpl =
-.PHONY: $(1)
-$(1): go.mod $(2)
-	go build -o $$(dir $$@) ./$$(dir $$@)
-endef
-$(foreach D,$(BUILD_TARGETS),$(eval $(call gobuild_tmpl, $(D), $(shell find $(dir $(D)) -name '*.go') )))
+.PHONY: scion-bat
+scion-bat:
+	go build -o $(BIN)/$@ ./bat/
+
+.PHONY: scion-bwtestclient
+scion-bwtestclient:
+	go build -o $(BIN)/$@ ./bwtester/bwtestclient/
+
+.PHONY: scion-bwtestserver
+scion-bwtestserver:
+	go build -o $(BIN)/$@ ./bwtester/bwtestserver/
+
+.PHONY: scion-imagefetcher
+scion-imagefetcher:
+	go build -o $(BIN)/$@ ./camerapp/imagefetcher/
+
+.PHONY: scion-imageserver
+scion-imageserver:
+	go build -o $(BIN)/$@ ./camerapp/imageserver/
+
+.PHONY: scion-netcat
+scion-netcat:
+	go build -o $(BIN)/$@ ./netcat/
+
+.PHONY: scion-sensorfetcher
+scion-sensorfetcher:
+	go build -o $(BIN)/$@ ./sensorapp/sensorfetcher/
+
+.PHONY: scion-sensorserver
+scion-sensorserver:
+	go build -o $(BIN)/$@ ./sensorapp/sensorserver/
+
+.PHONY: scion-ssh
+scion-ssh:
+	go build -o $(BIN)/$@ ./ssh/client/
+
+.PHONY: scion-sshd
+scion-sshd:
+	go build -o $(BIN)/$@ ./ssh/server/
+
+.PHONY: scion-webapp
+scion-webapp:
+	go build -o $(BIN)/$@ ./webapp/
+
+.PHONY: example-helloworld
+example-helloworld:
+	go build -o $(BIN)/$@ ./_examples/helloworld/
+
+.PHONY: example-shttp-client
+example-shttp-client:
+	go build -o $(BIN)/$@ ./_examples/shttp/client
+
+.PHONY: example-shttp-server
+example-shttp-server:
+	go build -o $(BIN)/$@ ./_examples/shttp/server

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 .PHONY: all clean test lint build install
 
 BIN = bin
-# default DESTDIR for installation uses fallback sequence, as documented by go install.
-DESTDIR = $(shell go env GOBIN GOPATH | eval; echo $${GOBIN:-$${GOPATH:-$${HOME}/go}/bin})
+# Default DESTDIR for installation uses fallback sequence, as documented by go install;
+#   This Make-escaped ($ replaced with $$) shell oneliner sources the
+#   environment as returned by go env, and uses the "Default Values" parameter
+#   expansion ${variable:-default} to implement the fallback sequence:
+#     $GOBIN, else $GOPATH/bin, else $HOME/go/bin
+DESTDIR = $(shell set -a; eval $$( go env ); echo $${GOBIN:-$${GOPATH:-$${HOME}/go}/bin})
 
 all: lint build
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: scion-bat \
 	scion-imagefetcher scion-imageserver \
 	scion-netcat \
 	scion-sensorfetcher scion-sensorserver \
-	scion-sshd scion-sshd \
+	scion-ssh scion-sshd \
 	example-helloworld \
 	example-shttp-client example-shttp-server
 

--- a/_examples/helloworld/helloworld_integration_test.go
+++ b/_examples/helloworld/helloworld_integration_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	name = "helloworld"
-	cmd  = "helloworld"
+	cmd  = "bin/example-helloworld"
 )
 
 func TestHelloworldSample(t *testing.T) {

--- a/_examples/helloworld/helloworld_integration_test.go
+++ b/_examples/helloworld/helloworld_integration_test.go
@@ -25,13 +25,14 @@ import (
 
 const (
 	name = "helloworld"
-	cmd  = "bin/example-helloworld"
+	bin  = "example-helloworld"
 )
 
 func TestHelloworldSample(t *testing.T) {
 	if err := integration.Init(name); err != nil {
 		t.Fatalf("Failed to init: %s\n", err)
 	}
+  cmd := integration.AppBinPath(bin)
 	// Common arguments
 	cmnArgs := []string{}
 	// Server

--- a/bwtester/bwtestclient/bwtestclient_integration_test.go
+++ b/bwtester/bwtestclient/bwtestclient_integration_test.go
@@ -24,14 +24,17 @@ import (
 
 const (
 	name      = "bwtester"
-	clientCmd = "bin/scion-bwtestclient"
-	serverCmd = "bin/scion-bwtestserver"
+	clientBin = "scion-bwtestclient"
+	serverBin = "scion-bwtestserver"
 )
 
 func TestIntegrationBwtestclient(t *testing.T) {
 	if err := integration.Init(name); err != nil {
 		t.Fatalf("Failed to init: %s\n", err)
 	}
+  clientCmd := integration.AppBinPath(clientBin)
+  serverCmd := integration.AppBinPath(serverBin)
+
 	// Common arguments
 	cmnArgs := []string{}
 	// Server

--- a/bwtester/bwtestclient/bwtestclient_integration_test.go
+++ b/bwtester/bwtestclient/bwtestclient_integration_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	name = "bwtester"
-	clientCmd  = "bwtestclient"
-	serverCmd  = "bwtestserver"
+	name      = "bwtester"
+	clientCmd = "bin/scion-bwtestclient"
+	serverCmd = "bin/scion-bwtestserver"
 )
 
 func TestIntegrationBwtestclient(t *testing.T) {

--- a/netcat/netcat_integration_test.go
+++ b/netcat/netcat_integration_test.go
@@ -41,7 +41,7 @@ func TestSCIONNetcat(t *testing.T) {
 	}()
 
 	// Check we are running the right scion-netcat, inspect the help
-	cmd := exec.Command("netcat",
+	cmd := exec.Command("bin/scion-netcat",
 		"--help",
 	)
 	ncOut, _ := cmd.StdoutPipe()
@@ -62,7 +62,7 @@ func TestSCIONNetcat(t *testing.T) {
 	// Start the actual test
 	testMessage := "Hello World!"
 	// Server command
-	cmd = exec.Command("netcat",
+	cmd = exec.Command("bin/scion-netcat",
 		"-l",
 		"1234",
 	)
@@ -83,7 +83,7 @@ func TestSCIONNetcat(t *testing.T) {
 	echoOut, _ := echoCmd.StdoutPipe()
 
 	// Client command
-	cmd = exec.Command("netcat",
+	cmd = exec.Command("bin/scion-netcat",
 		"1-ff00:0:110,[127.0.0.1]:1234",
 	)
 	cmd.Stdin = echoOut

--- a/pkg/integration/apps.go
+++ b/pkg/integration/apps.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -51,6 +52,7 @@ type ScionAppsIntegration struct {
 
 // NewAppsIntegration returns an implementation of the Integration interface.
 // Start{Client|Server} will run the binary program with name and use the given arguments for the client/server.
+// Paths to the client/server binaries are relative to the project root.
 // Use SrcIAReplace and DstIAReplace in arguments as placeholder for the source and destination IAs.
 // When starting a client/server the placeholders will be replaced with the actual values.
 // The server should output the ReadySignal to Stdout once it is ready to accept clients.
@@ -89,7 +91,7 @@ func (sai *ScionAppsIntegration) StartServer(ctx context.Context,
 	log.Debug(fmt.Sprintf("Running server command: %v %v\n", sai.serverCmd, strings.Join(args, " ")))
 
 	r := &appsWaiter{
-		exec.CommandContext(ctx, sai.serverCmd, args...),
+		exec.CommandContext(ctx, path.Join(projectRoot, sai.serverCmd), args...),
 		make(chan bool, 1),
 		make(chan bool, 1),
 	}
@@ -213,7 +215,7 @@ func (sai *ScionAppsIntegration) StartClient(ctx context.Context,
 	log.Debug(fmt.Sprintf("Running client command: %v %v\n", sai.clientCmd, strings.Join(args, " ")))
 
 	r := &appsWaiter{
-		exec.CommandContext(ctx, sai.clientCmd, args...),
+		exec.CommandContext(ctx, path.Join(projectRoot, sai.clientCmd), args...),
 		make(chan bool, 1),
 		make(chan bool, 1),
 	}

--- a/pkg/integration/apps.go
+++ b/pkg/integration/apps.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -52,7 +51,6 @@ type ScionAppsIntegration struct {
 
 // NewAppsIntegration returns an implementation of the Integration interface.
 // Start{Client|Server} will run the binary program with name and use the given arguments for the client/server.
-// Paths to the client/server binaries are relative to the project root.
 // Use SrcIAReplace and DstIAReplace in arguments as placeholder for the source and destination IAs.
 // When starting a client/server the placeholders will be replaced with the actual values.
 // The server should output the ReadySignal to Stdout once it is ready to accept clients.
@@ -91,7 +89,7 @@ func (sai *ScionAppsIntegration) StartServer(ctx context.Context,
 	log.Debug(fmt.Sprintf("Running server command: %v %v\n", sai.serverCmd, strings.Join(args, " ")))
 
 	r := &appsWaiter{
-		exec.CommandContext(ctx, path.Join(projectRoot, sai.serverCmd), args...),
+		exec.CommandContext(ctx, sai.serverCmd, args...),
 		make(chan bool, 1),
 		make(chan bool, 1),
 	}
@@ -215,7 +213,7 @@ func (sai *ScionAppsIntegration) StartClient(ctx context.Context,
 	log.Debug(fmt.Sprintf("Running client command: %v %v\n", sai.clientCmd, strings.Join(args, " ")))
 
 	r := &appsWaiter{
-		exec.CommandContext(ctx, path.Join(projectRoot, sai.clientCmd), args...),
+		exec.CommandContext(ctx, sai.clientCmd, args...),
 		make(chan bool, 1),
 		make(chan bool, 1),
 	}

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -100,6 +100,11 @@ func Init(name string) (err error) {
 	return err
 }
 
+// AppBinPath returns the path to a scion-apps binary built with the projects Makefile.
+func AppBinPath(name string) string {
+	return path.Join(projectRoot, "bin", name)
+}
+
 // IAPairs returns all IAPairs that should be tested.
 func IAPairs(hostAddr sintegration.HostAddr) []sintegration.IAPair {
 	if hostAddr == nil {

--- a/ssh/scionutils/policy_conn_test.go
+++ b/ssh/scionutils/policy_conn_test.go
@@ -119,14 +119,16 @@ type mockPath struct {
 	id int
 }
 
-func (p *mockPath) Fingerprint() snet.PathFingerprint { return snet.PathFingerprint(strconv.Itoa(p.id)) }
-func (p *mockPath) OverlayNextHop() *net.UDPAddr      { return nil }
-func (p *mockPath) Path() *spath.Path                 { return nil }
-func (p *mockPath) Interfaces() []snet.PathInterface  { return nil }
-func (p *mockPath) Destination() addr.IA              { return addr.IA{} }
-func (p *mockPath) MTU() uint16                       { return 0 }
-func (p *mockPath) Expiry() time.Time                 { return time.Time{} }
-func (p *mockPath) Copy() snet.Path                   { return &mockPath{id: p.id} }
+func (p *mockPath) Fingerprint() snet.PathFingerprint {
+	return snet.PathFingerprint(strconv.Itoa(p.id))
+}
+func (p *mockPath) OverlayNextHop() *net.UDPAddr     { return nil }
+func (p *mockPath) Path() *spath.Path                { return nil }
+func (p *mockPath) Interfaces() []snet.PathInterface { return nil }
+func (p *mockPath) Destination() addr.IA             { return addr.IA{} }
+func (p *mockPath) MTU() uint16                      { return 0 }
+func (p *mockPath) Expiry() time.Time                { return time.Time{} }
+func (p *mockPath) Copy() snet.Path                  { return &mockPath{id: p.id} }
 
 func makePaths(num int) []snet.Path {
 	paths := make([]snet.Path, num)


### PR DESCRIPTION
- Build out-of-source into `bin/` directory
- Use binaries in bin/ for integration tests instead of installing
- Binary names now  match names also used by the packages
- make install installs into the "correct" directory also used by `go install`
- update golangci-lint version (and run gomft to make lint pass)

Fixes #144 
Fixes #118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/145)
<!-- Reviewable:end -->
