### PR TITLE
Moving webapp GAE api keys server

### DIFF
--- a/webapp-apikeys/README.md
+++ b/webapp-apikeys/README.md
@@ -1,0 +1,31 @@
+# SCIONLab Webapp API Keys
+
+`webapp-apikeys` is a Google App Engine web application designed to store and retrieve API Keys which are not desirable to publish in public open source code repositories. It has been moved from its original location at [https://github.com/netsec-ethz/scion-viz/tree/master/python/appengine](https://github.com/netsec-ethz/scion-viz/tree/master/python/appengine).
+
+This is used to primarily supply API keys from services like Google Maps, Geolocation, Firebase, and others used by SCIONLab visualization tools like [webapp](../webapp).
+
+## Structure
+
+This web application creates a simple key-value paired Datastore, with a permissions-based App Admin Page for it's main page to make editing easy, and one URL for retrieving the JSON-formatted dictionary of key-value pairs using the pattern: `https://[host]/getconfig`.
+
+## Access
+
+Permissions to modify the deployed application have to be granted by a project Owner.
+
+- GAE Project Name: `scion-viz`
+- Host & App Admin Page: [https://my-project-1470640410708.appspot.com](https://my-project-1470640410708.appspot.com)
+- GAE Permissions: [https://console.cloud.google.com/iam-admin/iam?project=my-project-1470640410708](https://console.cloud.google.com/iam-admin/iam?project=my-project-1470640410708)
+- GAE Dashboard: [https://console.cloud.google.com/appengine?project=my-project-1470640410708](https://console.cloud.google.com/appengine?project=my-project-1470640410708)
+
+## Deployment
+
+1. Prepare your development environment: [https://cloud.google.com/appengine/docs/standard/python/setting-up-environment](https://cloud.google.com/appengine/docs/standard/python/setting-up-environment)
+
+1. Read the Google Cloud application upload documentation: [https://cloud.google.com/appengine/docs/standard/python/tools/uploadinganapp](https://cloud.google.com/appengine/docs/standard/python/tools/uploadinganapp)
+
+1. Once you have the tools installed, from the application directory:
+
+    ```
+    gcloud app deploy --project my-project-1470640410708
+    ```
+

--- a/webapp-apikeys/app.yaml
+++ b/webapp-apikeys/app.yaml
@@ -1,0 +1,16 @@
+runtime: python27
+api_version: 1
+threadsafe: yes
+
+handlers:
+- url: /
+  script: main.app
+  secure: always
+
+- url: /setconfig
+  script: main.app
+  secure: always
+
+- url: /getconfig
+  script: getconfig.app
+  secure: always

--- a/webapp-apikeys/getconfig.py
+++ b/webapp-apikeys/getconfig.py
@@ -1,0 +1,25 @@
+import webapp2
+import json
+
+import visconfig
+
+
+class GetConfig(webapp2.RequestHandler):
+
+    def post(self):
+
+        self.response.headers['Content-Type'] = 'application/json'
+
+        query = visconfig.VisConfig.all()
+        num = query.count()
+        items = query.fetch(num)
+        obj = {}
+        for item in items:
+            obj[item.lookuptag] = item.value
+
+        self.response.out.write(json.dumps(obj))
+
+
+app = webapp2.WSGIApplication([
+    ('/getconfig', GetConfig),
+], debug=True)

--- a/webapp-apikeys/main.py
+++ b/webapp-apikeys/main.py
@@ -1,0 +1,150 @@
+import cgi
+
+from google.appengine.api import users
+import webapp2
+
+import visconfig
+
+
+class MainPage(webapp2.RequestHandler):
+    def get(self):
+        user = users.get_current_user()
+
+        # only admins registered with this app can request to store data
+        if users.is_current_user_admin():
+
+            self.response.out.write("""
+                <html>
+                <head>
+                <style>
+                body {
+                 font-family: arial, sans-serif;
+                }
+                table {
+                 border-collapse: collapse;
+                 width: 100%%;
+                }
+                td, th {
+                 border: 1px solid #ddd;
+                 text-align: left;
+                 padding: 8px;
+                }
+                tr:nth-child(even) {
+                 background-color: #ddd;
+                }
+                </style>
+                </head>
+                <body>
+                  <h2>SCION Visualization Administrator Tools</h2>
+                  Administrator: %s (%s)<br><br>
+            """ % (user.nickname(), user.email()))
+
+            # scan configuration for current stored values and display
+            query = visconfig.VisConfig.all()
+            num = query.count()
+            items = query.fetch(num)
+            self.response.out.write("""
+                    Current configuration storage<br><table>
+                      <tr>
+                        <th>lookuptag</th>
+                        <th>value</th>
+                        <th>comment</th>
+                        <th>username</th>
+                      </tr>
+            """)
+            for item in items:
+                self.response.out.write("""
+                      <tr>
+                        <td>%s</td>
+                        <td>%s</td>
+                        <td>%s</td>
+                        <td>%s</td>
+                      </tr>
+                """ % (item.lookuptag, item.value, item.comment,
+                       item.username))
+            self.response.out.write("""
+                    </table><p>
+            """)
+            self.response.out.write("""
+                     Add/Update Visualization Configuration<br>
+                     <form action="/setconfig" method="post">
+                        Config Key:<br><textarea rows="1" cols="70"
+                            name="lookuptag"></textarea><br>
+                        Config Value:<br><textarea rows="2" cols="70"
+                            name="vizvalue"></textarea><br>
+                        Config Reason:<br><textarea rows="2" cols="70"
+                            name="reason"></textarea><br>
+                        <div align="left">
+                          <p><input type="submit" name="submit"
+                              value="Submit Visualization Configuration" /><p>
+                        </div>
+                      </form>
+                     <br>
+                </body>
+              </html>""")
+
+        else:
+            self.redirect(users.create_login_url(self.request.uri))
+
+
+class SetConfig(webapp2.RequestHandler):
+    def post(self):
+        user = users.get_current_user()
+
+        # only admins registered with this app can request to store
+        # authentication token for the service
+        if users.is_current_user_admin():
+
+            lookup = self.request.get('lookuptag')
+            value = self.request.get('vizvalue')
+            comments = self.request.get('reason')
+            user = users.get_current_user()
+
+            # grab latest proper auth token from our cache
+            query = visconfig.VisConfig.all()
+            query.filter('lookuptag =', lookup)
+            num = query.count()
+
+            # store result, updating old one first
+            if num == 1:
+                credential = query.get()
+                credential.value = value
+                credential.username = user.email()
+                credential.comment = comments
+            else:
+                credential = visconfig.VisConfig(
+                    value=value, username=user.email(), comment=comments,
+                    lookuptag=lookup)
+
+            credential.put()
+            key = credential.key()
+            insertSuccess = True
+            if not key.has_id_or_name():
+                insertSuccess = False
+
+            # display result
+            self.response.out.write('<html><body>')
+            self.response.out.write('Config Updated Lookup Tag: ')
+            self.response.out.write(cgi.escape(lookup))
+            self.response.out.write('<br>')
+            self.response.out.write('Config Value: ')
+            self.response.out.write(cgi.escape(value))
+            self.response.out.write('<br>')
+            self.response.out.write('Config Comments: ')
+            self.response.out.write(cgi.escape(comments))
+            self.response.out.write('<br>')
+            self.response.out.write('Update Result: ')
+            if insertSuccess:
+                self.response.out.write('Success')
+            else:
+                self.response.out.write('Failed')
+            self.response.out.write('</body></html>')
+
+        else:
+            self.redirect(users.create_login_url(self.request.uri))
+
+
+app = webapp2.WSGIApplication([
+    ('/', MainPage),
+    ('/setconfig', SetConfig),
+], debug=True)

--- a/webapp-apikeys/visconfig.py
+++ b/webapp-apikeys/visconfig.py
@@ -1,0 +1,10 @@
+from google.appengine.ext import db
+
+
+class VisConfig(db.Model):
+    # store config values to be recalled
+    value = db.TextProperty(required=True)
+    lookuptag = db.StringProperty(required=True)
+    inserted = db.DateTimeProperty(auto_now=True)
+    username = db.StringProperty(required=True)
+    comment = db.TextProperty()


### PR DESCRIPTION
This PR moves the python Google App Engine server source used to store webapp's API Keys. This also adds a `README.md` for future maintainers.

Since this is an active component of webapp, it should be maintained in a repo where changes can be made if needed.

Closes: https://github.com/netsec-ethz/scion-apps/issues/58.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/146)
<!-- Reviewable:end -->
