### PR TITLE
netcat integration test

### DIFF
--- a/netcat/modes/quic-modes.go
+++ b/netcat/modes/quic-modes.go
@@ -102,9 +102,6 @@ func DoDialQUIC(remoteAddr string) io.ReadWriteCloser {
 		&tls.Config{
 			InsecureSkipVerify: true,
 			NextProtos:         []string{nextProto},
-			// TODO: remove the hack below, and fix anywhere between appquic.Dial and quic-go/client.go newClient
-			ServerName:         "example.com", // this is a stupid workaround to not hit SplitHostPort
-			// on a SCION address in quic-go newClient
 		},
 		&quic.Config{KeepAlive: true},
 	)

--- a/netcat/modes/quic-modes.go
+++ b/netcat/modes/quic-modes.go
@@ -102,9 +102,6 @@ func DoDialQUIC(remoteAddr string) io.ReadWriteCloser {
 		&tls.Config{
 			InsecureSkipVerify: true,
 			NextProtos:         []string{nextProto},
-			// TODO: remove the hack below, and fix anywhere between appquic.Dial and quic-go/client.go newClient
-			ServerName: "example.com", // this is a stupid workaround to not hit SplitHostPort
-			// on a SCION address in quic-go newClient
 		},
 		&quic.Config{KeepAlive: true},
 	)

--- a/netcat/modes/quic-modes.go
+++ b/netcat/modes/quic-modes.go
@@ -102,6 +102,9 @@ func DoDialQUIC(remoteAddr string) io.ReadWriteCloser {
 		&tls.Config{
 			InsecureSkipVerify: true,
 			NextProtos:         []string{nextProto},
+			// TODO: remove the hack below, and fix anywhere between appquic.Dial and quic-go/client.go newClient
+			ServerName:         "example.com", // this is a stupid workaround to not hit SplitHostPort
+			// on a SCION address in quic-go newClient
 		},
 		&quic.Config{KeepAlive: true},
 	)

--- a/netcat/modes/quic-modes.go
+++ b/netcat/modes/quic-modes.go
@@ -102,6 +102,9 @@ func DoDialQUIC(remoteAddr string) io.ReadWriteCloser {
 		&tls.Config{
 			InsecureSkipVerify: true,
 			NextProtos:         []string{nextProto},
+			// TODO: remove the hack below, and fix anywhere between appquic.Dial and quic-go/client.go newClient
+			ServerName: "example.com", // this is a stupid workaround to not hit SplitHostPort
+			// on a SCION address in quic-go newClient
 		},
 		&quic.Config{KeepAlive: true},
 	)

--- a/netcat/netcat_integration_test.go
+++ b/netcat/netcat_integration_test.go
@@ -104,16 +104,33 @@ func TestIntegrationScionNetcat(t *testing.T) {
 			t.Fatalf("Error during tests err: %v", err)
 		}
 	}
+}
 
+func TestIntegrationScionNetcatUDP(t *testing.T) {
 	// UDP tests
 	// Common arguments
-	cmnArgs = []string{"-vv", "-u"}
+	cmnArgs := []string{"-vv", "-u"}
 
 	// Server
-	serverPort = "1234"
-	serverArgs = []string{"-l", serverPort}
+	serverPort := "1234"
+	serverArgs := []string{"-l", serverPort}
 	serverArgs = append(cmnArgs, serverArgs...)
-	testCases = []struct {
+
+	testMessage := "Hello UDP World!"
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	clientBinWrapperCmd, err := wrapperCommand(tmpDir, fmt.Sprintf("echo -e '%s'", testMessage),
+		integration.AppBinPath(clientBin))
+	if err != nil {
+		t.Fatalf("Failed to wrap scion-netcat input: %s\n", err)
+	}
+	clientCmd := clientBinWrapperCmd
+	serverCmd := integration.AppBinPath(serverBin)
+
+	testCases := []struct {
 		Name              string
 		Args              []string
 		ServerOutMatchFun func(bool, string) bool
@@ -148,6 +165,7 @@ func TestIntegrationScionNetcat(t *testing.T) {
 		}
 	}
 }
+
 
 func wrapperCommand(tmpDir string, inputSource string, command string) (wrapperCmd string, err error){
 	wrapperCmd = path.Join(tmpDir, fmt.Sprintf("%s_wrapper.sh", serverBin))

--- a/netcat/netcat_integration_test.go
+++ b/netcat/netcat_integration_test.go
@@ -12,103 +12,142 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build old_integration
+// +build integration
 
 package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
-	"io/ioutil"
-	"os/exec"
-	"strings"
+	"os"
 	"testing"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	"github.com/netsec-ethz/scion-apps/pkg/integration"
 )
 
-func TestSCIONNetcat(t *testing.T) {
+const (
+	name      = "netcat"
+	clientBin = "scion-netcat"
+	serverBin = "scion-netcat"
+)
+
+func TestIntegrationScionNetcat(t *testing.T) {
+	if err := integration.Init(name); err != nil {
+		t.Fatalf("Failed to init: %s\n", err)
+	}
 	// Start a scion-netcat server socket and query it with a scion-netcat client
-	var commands []*exec.Cmd
-	defer func() {
-		// cleanup after test
-		for _, cmd := range commands {
-			if err := cmd.Process.Kill(); err != nil {
-				fmt.Printf("Failed to kill process: %v", err)
-			}
-		}
-	}()
+	// Common arguments
+	cmnArgs := []string{"-vv"}
+	// Server
+	serverPort := "1234"
+	serverArgs := []string{"-l", serverPort}
+	serverArgs = append(cmnArgs, serverArgs...)
 
-	// Check we are running the right scion-netcat, inspect the help
-	cmd := exec.Command("bin/scion-netcat",
-		"--help",
-	)
-	ncOut, _ := cmd.StdoutPipe()
-	log.Info("Run netcat help", "cmd", fmt.Sprintf("%s %s", cmd.Path, cmd.Args))
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Error during help %v: %v", "netcat", err)
-	}
-	ncStdOutput, _ := ioutil.ReadAll(ncOut)
-	_ = cmd.Wait()
-
-	// Check help output
-	if strings.Contains(string(ncStdOutput), "SCION") {
-		fmt.Println("Using scion-netcat")
-	} else {
-		t.Fatalf("Wrong netcat on PATH. Output=%s", ncStdOutput)
-	}
-
-	// Start the actual test
 	testMessage := "Hello World!"
-	// Server command
-	cmd = exec.Command("bin/scion-netcat",
-		"-l",
-		"1234",
-	)
-	serverOut, _ := cmd.StdoutPipe()
-	serverStdoutScanner := bufio.NewScanner(serverOut)
-	log.Info("Start server", "cmd", fmt.Sprintf("%s %s", cmd.Path, cmd.Args))
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Error during netcat server socket listen %v: %v", "netcat", err)
+	clientBinWrapperCmd, err := wrapperCommand(fmt.Sprintf("echo -e '%s'", testMessage),
+		integration.AppBinPath(clientBin))
+	if err != nil {
+		t.Fatalf("Failed to wrap scion-netcat input: %s\n", err)
 	}
-	commands = append(commands, cmd)
-	time.Sleep(250 * time.Millisecond)
+	clientCmd := clientBinWrapperCmd
+	serverCmd := integration.AppBinPath(serverBin)
 
-	// Echo command
-	echoCmd := exec.Command("echo",
-		"-e",
-		fmt.Sprintf("\n\n%s\n", testMessage),
-	)
-	echoOut, _ := echoCmd.StdoutPipe()
-
-	// Client command
-	cmd = exec.Command("bin/scion-netcat",
-		"1-ff00:0:110,[127.0.0.1]:1234",
-	)
-	cmd.Stdin = echoOut
-	log.Info("Run client", "cmd", fmt.Sprintf("%s %s", cmd.Path, cmd.Args))
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Error during netcat piping on client side %v: %v", "netcat", err)
+	// QUIC tests (default mode)
+	testCases := []struct {
+		Name              string
+		Args              []string
+		ServerOutMatchFun func(bool, string) bool
+		ServerErrMatchFun func(bool, string) bool
+		ClientOutMatchFun func(bool, string) bool
+		ClientErrMatchFun func(bool, string) bool
+	}{
+		{
+			"client_help",
+			append(cmnArgs, "--help"),
+			nil,
+			nil,
+			integration.RegExp("^.*SCION.*$"),
+			//integration.Contains("SCION"),
+			nil,
+		},
+		{
+			"client_hello",
+			append(cmnArgs, integration.DstAddrPattern + ":" + serverPort),
+			integration.RegExp(fmt.Sprintf("^%s$", testMessage)),
+			nil,
+			nil,
+			nil,
+		},
 	}
-	commands = append(commands, cmd)
 
-	// Run echo piped into netcat client
-	if err := echoCmd.Run(); err != nil {
-		t.Fatalf("Error during echo to netcat pipe on client side %v: %v", "echo | netcat", err)
-	}
+	for _, tc := range testCases {
+		in := integration.NewAppsIntegration(name, tc.Name, clientCmd, serverCmd, tc.Args, serverArgs, true)
+		in.ServerStdout(tc.ServerOutMatchFun)
+		in.ServerStderr(tc.ServerErrMatchFun)
+		in.ClientStdout(tc.ClientOutMatchFun)
+		in.ClientStderr(tc.ClientErrMatchFun)
 
-	// Check server output
-	fullServerOutput := ""
-	for serverStdoutScanner.Scan() {
-		serverOutput := serverStdoutScanner.Text()
-		fullServerOutput += fmt.Sprintln(serverOutput)
-		if strings.Contains(serverOutput, testMessage) {
-			fmt.Printf("Server received client message: %s\n", serverOutput)
-			break
+		hostAddr := integration.HostAddr
+
+		IAPairs := integration.IAPairs(hostAddr)
+		IAPairs = IAPairs[:5]
+
+		if err := integration.RunTests(in, IAPairs, integration.DefaultClientTimeout, 250 * time.Millisecond); err != nil {
+			t.Fatalf("Error during tests err: %v", err)
 		}
 	}
-	if err := serverStdoutScanner.Err(); err != nil {
-		t.Fatalf("Server failed to receive `%s`. Output=%s", testMessage, fullServerOutput)
+
+	// Common arguments
+	cmnArgs = []string{"-vv -u"}
+	// UDP tests
+	testCases = []struct {
+		Name              string
+		Args              []string
+		ServerOutMatchFun func(bool, string) bool
+		ServerErrMatchFun func(bool, string) bool
+		ClientOutMatchFun func(bool, string) bool
+		ClientErrMatchFun func(bool, string) bool
+	}{
+		{
+			"client_hello_UDP",
+			append(cmnArgs, integration.DstAddrPattern + ":" + serverPort),
+			integration.RegExp(fmt.Sprintf("^%s$", testMessage)),
+			nil,
+			nil,
+			nil,
+		},
 	}
+
+	for _, tc := range testCases {
+		in := integration.NewAppsIntegration(name, tc.Name, clientCmd, serverCmd, tc.Args, serverArgs, true)
+		in.ServerStdout(tc.ServerOutMatchFun)
+		in.ServerStderr(tc.ServerErrMatchFun)
+		in.ClientStdout(tc.ClientOutMatchFun)
+		in.ClientStderr(tc.ClientErrMatchFun)
+
+		hostAddr := integration.HostAddr
+
+		IAPairs := integration.IAPairs(hostAddr)
+		IAPairs = IAPairs[:5]
+
+		if err := integration.RunTests(in, IAPairs, integration.DefaultClientTimeout, 250 * time.Millisecond); err != nil {
+			t.Fatalf("Error during tests err: %v", err)
+		}
+	}
+}
+
+func wrapperCommand(inputSource string, command string) (wrapperCmd string, err error){
+	wrapperCmd = integration.AppBinPath(fmt.Sprintf("%s_wrapper.sh", serverBin))
+	f, err := os.OpenFile(wrapperCmd, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to create %s: %v", wrapperCmd, err))
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	defer w.Flush()
+	_, _ = w.WriteString(fmt.Sprintf("#!/bin/bash\ntimeout 5 /bin/bash -c \"%s | %s $1 $2 $3 $4\"",
+		inputSource, command))
+	return wrapperCmd, nil
 }

--- a/pkg/appnet/appquic/appquic.go
+++ b/pkg/appnet/appquic/appquic.go
@@ -66,9 +66,6 @@ func Dial(remote string, tlsConf *tls.Config, quicConf *quic.Config) (quic.Sessi
 	if err != nil {
 		return nil, err
 	}
-	if tlsConf.ServerName == "" {
-		tlsConf.ServerName = mangleSCIONAddr(raddr)
-	}
 	return DialAddr(raddr, remote, tlsConf, quicConf)
 }
 
@@ -87,6 +84,7 @@ func DialAddr(raddr *snet.UDPAddr, host string, tlsConf *tls.Config, quicConf *q
 	if err != nil {
 		return nil, err
 	}
+	host = appnet.MangleSCIONAddr(host)
 	session, err := quic.Dial(sconn, raddr, host, tlsConf, quicConf)
 	if err != nil {
 		return nil, err
@@ -99,9 +97,6 @@ func DialEarly(remote string, tlsConf *tls.Config, quicConf *quic.Config) (quic.
 	raddr, err := appnet.ResolveUDPAddr(remote)
 	if err != nil {
 		return nil, err
-	}
-	if tlsConf.ServerName == "" {
-		tlsConf.ServerName = mangleSCIONAddr(raddr)
 	}
 	return DialAddrEarly(raddr, remote, tlsConf, quicConf)
 }
@@ -116,6 +111,7 @@ func DialAddrEarly(raddr *snet.UDPAddr, host string, tlsConf *tls.Config, quicCo
 	if err != nil {
 		return nil, err
 	}
+	host = appnet.MangleSCIONAddr(host)
 	session, err := quic.DialEarly(sconn, raddr, host, tlsConf, quicConf)
 	if err != nil {
 		return nil, err
@@ -129,17 +125,6 @@ func ensurePathDefined(raddr *snet.UDPAddr) error {
 		return appnet.SetDefaultPath(raddr)
 	}
 	return nil
-}
-
-// mangleSCIONAddr mangles a SCION address
-func mangleSCIONAddr(raddr *snet.UDPAddr) string {
-	// Turn this into [IA,IP]:port format.
-	// Same mangling as for the host part in MangleSCIONAddrURL github.com/netsec-ethz/scion-apps/pkg/shttp/transport.go
-	mangledAddr := fmt.Sprintf("[%s,%s]", raddr.IA, raddr.Host.IP)
-	if raddr.Host.Port != 0 {
-		mangledAddr += fmt.Sprintf(":%d", raddr.Host.Port)
-	}
-	return mangledAddr
 }
 
 // ListenPort listens for QUIC connections on a SCION/UDP port.

--- a/pkg/appnet/hosts.go
+++ b/pkg/appnet/hosts.go
@@ -214,3 +214,51 @@ func addrFromString(address string) (snet.SCIONAddress, error) {
 func addrToString(addr snet.SCIONAddress) string {
 	return fmt.Sprintf("%s,[%s]", addr.IA, addr.Host)
 }
+
+// MangleSCIONAddr mangles a SCION address string (if it is one) so it can be
+// safely used in the host part of a URL.
+func MangleSCIONAddr(address string) string {
+
+	raddr, err := snet.ParseUDPAddr(address)
+	if err != nil {
+		return address
+	}
+
+	// Turn this into [IA,IP]:port format. This is a valid host in a URI, as per
+	// the "IP-literal" case in RFC 3986, §3.2.2.
+	// Unfortunately, this is not currently compatible with snet.ParseUDPAddr,
+	// so this will have to be _unmangled_ before use.
+	mangledAddr := fmt.Sprintf("[%s,%s]", raddr.IA, raddr.Host.IP)
+	if raddr.Host.Port != 0 {
+		mangledAddr += fmt.Sprintf(":%d", raddr.Host.Port)
+	}
+	return mangledAddr
+}
+
+// UnmangleSCIONAddr returns a SCION address that can be parsed with
+// with snet.ParseUDPAddr.
+// If the input is not a SCION address (e.g. a hostname), the address is
+// returned unchanged.
+// This parses the address, so that it can safely join host and port, with the
+// brackets in the right place. Yes, this means this will be parsed twice.
+//
+// Assumes that address always has a port (this is enforced by the http3
+// roundtripper code)
+func UnmangleSCIONAddr(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil || port == "" {
+		panic(fmt.Sprintf("UnmangleSCIONAddr assumes that address is of the form host:port %s", err))
+	}
+	// brackets are removed from [I-A,IP] part by SplitHostPort, so this can be
+	// parsed with ParseUDPAddr:
+	udpAddr, err := snet.ParseUDPAddr(host)
+	if err != nil {
+		return address
+	}
+	p, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return address
+	}
+	udpAddr.Host.Port = int(p)
+	return udpAddr.String()
+}

--- a/pkg/integration/apps.go
+++ b/pkg/integration/apps.go
@@ -406,3 +406,19 @@ func RegExp(regularExpression string) func(prev bool, line string) bool {
 		return prev || matched // return true if any output line matches the expression
 	}
 }
+
+func NoPanic() func(prev bool, line string) bool {
+	return func(prev bool, line string) bool {
+		matched, err := regexp.MatchString("^.*panic: .*$", line)
+		if err != nil {
+			// invalid regexp, don't count as a match
+			return prev
+		}
+		if init, err := regexp.MatchString("^.*Registered with dispatcher.*$", line); err == nil {
+			if init {
+				return init
+			}
+		}
+		return prev && !matched
+	}
+}

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -233,7 +233,6 @@ func findAnyHostInLocalAS(ctx context.Context, sciondConn sciond.Connector) (net
 	return bsAddr.IP, nil
 }
 
-
 // Duplicated from "github.com/scionproto/scion/go/lib/integration", but do not swallow error
 func (s *serverStop) Close() error {
 	s.cancel()

--- a/pkg/shttp/transport_test.go
+++ b/pkg/shttp/transport_test.go
@@ -62,9 +62,9 @@ func TestMangleSCIONAddrURL(t *testing.T) {
 			if _, _, err := net.SplitHostPort(u.Host); err != nil {
 				continue
 			}
-			unmangled := unmangleSCIONAddr(u.Host)
+			unmangled := appnet.UnmangleSCIONAddr(u.Host)
 			if unmangled != tc.HostPort {
-				t.Fatalf("unmangleSCIONAddr('%s') returned different result, actual='%s', expected='%s'", u.Host, unmangled, tc.HostPort)
+				t.Fatalf("UnmangleSCIONAddr('%s') returned different result, actual='%s', expected='%s'", u.Host, unmangled, tc.HostPort)
 			}
 		}
 	}
@@ -96,7 +96,7 @@ func TestRoundTripper(t *testing.T) {
 	// expected will be set in the test loop, below
 	var expected string
 	testDial := func(network, address string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlySession, error) {
-		unmangled := unmangleSCIONAddr(address)
+		unmangled := appnet.UnmangleSCIONAddr(address)
 		resolvedAddr, err := appnet.ResolveUDPAddr(unmangled)
 		if err != nil {
 			t.Fatalf("unexpected error when resolving address '%s' in roundtripper: %s", unmangled, err)


### PR DESCRIPTION
Add integration test for scion-netcat

Catch panic (and fail test, when SplitHostPort is called on a SCION address)
Add workaround to not trigger SplitHostPort in quic-go use by scion-netcat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/149)
<!-- Reviewable:end -->
