### PR TITLE
appnet: filter duplicate paths in QueryPaths

### DIFF
--- a/pkg/appnet/path_selection.go
+++ b/pkg/appnet/path_selection.go
@@ -124,21 +124,21 @@ func QueryPaths(ia addr.IA) ([]snet.Path, error) {
 // the one with latest expiry.
 func filterDuplicates(paths []snet.Path) []snet.Path {
 
-	set := make(map[snet.PathFingerprint]int)
+	chosenPath := make(map[snet.PathFingerprint]int)
 	for i := range paths {
 		fingerprint := paths[i].Fingerprint() // Fingerprint is a hash of p.Interfaces()
-		e, dupe := set[fingerprint]
+		e, dupe := chosenPath[fingerprint]
 		if !dupe || paths[e].Expiry().Before(paths[i].Expiry()) {
-			set[fingerprint] = i
+			chosenPath[fingerprint] = i
 		}
 	}
 
 	// filter, keep paths in input order:
 	kept := make(map[int]struct{})
-	for _, p := range set {
+	for _, p := range chosenPath {
 		kept[p] = struct{}{}
 	}
-	filtered := make([]snet.Path, 0, len(set))
+	filtered := make([]snet.Path, 0, len(kept))
 	for i := range paths {
 		if _, ok := kept[i]; ok {
 			filtered = append(filtered, paths[i])


### PR DESCRIPTION
Filter paths with identical sequence of interfaces. These duplicates
occur because sciond may return the same "effective" path with different
short-cut "upstream" parts. We don't need these duplicates, the paths are
identical for our purposes; we simply pick the one with latest expiry.

See also discussion in scionproto/scion#2445 (currently not merged).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/161)
<!-- Reviewable:end -->
