### PR TITLE
mpsquic server: track reply path by client connection ID

### DIFF
--- a/pkg/mpsquic/server.go
+++ b/pkg/mpsquic/server.go
@@ -86,7 +86,7 @@ func (c *returnPathConn) ReadFrom(p []byte) (int, net.Addr, error) {
 		shortHeaderConnIDLen := 4 // from quic config
 		serverConnID, err := parseDestConnectionID(p, shortHeaderConnIDLen)
 		if err == nil {
-			clientConnID, _ = c.clientConnIDs[serverConnID]
+			clientConnID = c.clientConnIDs[serverConnID]
 		}
 	}
 	saddr := &udpAddrEx{
@@ -170,7 +170,7 @@ func parseDestConnectionID(data []byte, shortHeaderConnIDLen int) (connectionID,
 }
 
 // parseSrcConnectionID parses the source connection ID of a packet.
-// The source connection ID is only availabe on long header packets.
+// The source connection ID is only available on long header packets.
 func parseSrcConnectionID(data []byte) (connectionID, error) {
 	if len(data) == 0 {
 		return connectionID{}, io.EOF

--- a/pkg/mpsquic/server.go
+++ b/pkg/mpsquic/server.go
@@ -16,12 +16,12 @@ package mpsquic
 
 import (
 	"crypto/tls"
+	"io"
 	"net"
 	"sync"
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/netsec-ethz/scion-apps/pkg/appnet"
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/spath"
 )
@@ -34,7 +34,7 @@ func ListenPort(port uint16, tlsConf *tls.Config, quicConfig *quic.Config) (quic
 	if err != nil {
 		return nil, err
 	}
-	conn := newReturnPathConn(sconn)
+	conn := newReturnPathConn(sconn, quicConfig)
 	return quic.Listen(conn, tlsConf, quicConfig)
 }
 
@@ -45,14 +45,29 @@ func ListenPort(port uint16, tlsConf *tls.Config, quicConfig *quic.Config) (quic
 // is a potential memory leak.
 type returnPathConn struct {
 	net.PacketConn
-	mutex sync.RWMutex
-	paths map[returnPathKey]returnPath
+	connIDLen     int
+	mutex         sync.RWMutex
+	paths         map[connectionID]returnPath   // clientConnID -> return path
+	clientConnIDs map[connectionID]connectionID // serverConnID -> clientConnID
 }
 
-func newReturnPathConn(conn *snet.Conn) *returnPathConn {
+// udpAddrEx is a wrapper around snet.UDPAddr, that additionally stores
+type udpAddrEx struct {
+	snet.UDPAddr
+	clientConnID connectionID
+	serverConnID connectionID
+}
+
+func newReturnPathConn(conn *snet.Conn, quicConfig *quic.Config) *returnPathConn {
+	connIDLen := 4 // default, from quic.Config docs
+	if quicConfig != nil && quicConfig.ConnectionIDLength != 0 {
+		connIDLen = quicConfig.ConnectionIDLength
+	}
 	return &returnPathConn{
-		PacketConn: conn,
-		paths:      make(map[returnPathKey]returnPath),
+		PacketConn:    conn,
+		connIDLen:     connIDLen,
+		paths:         make(map[connectionID]returnPath),
+		clientConnIDs: make(map[connectionID]connectionID),
 	}
 }
 
@@ -61,24 +76,52 @@ func (c *returnPathConn) ReadFrom(p []byte) (int, net.Addr, error) {
 	for _, ok := err.(*snet.OpError); err != nil && ok; {
 		n, addr, err = c.PacketConn.ReadFrom(p)
 	}
-	if err == nil {
-		if saddr, ok := addr.(*snet.UDPAddr); ok {
-			c.mutex.Lock()
-			defer c.mutex.Unlock()
-			c.paths[makeKey(saddr)] = returnPath{path: saddr.Path, nextHop: saddr.NextHop}
-			saddr.Path = nil // hide it,
-			saddr.NextHop = nil
+
+	if err != nil {
+		return n, addr, err
+	}
+
+	clientConnID, err := parseSrcConnectionID(p)
+	if err != nil {
+		shortHeaderConnIDLen := 4 // from quic config
+		serverConnID, err := parseDestConnectionID(p, shortHeaderConnIDLen)
+		if err == nil {
+			clientConnID, _ = c.clientConnIDs[serverConnID]
 		}
 	}
-	return n, addr, err
+	saddr := &udpAddrEx{
+		UDPAddr:      *addr.(*snet.UDPAddr),
+		clientConnID: clientConnID,
+	}
+
+	if (clientConnID != connectionID{}) { // expected case, otherwise just hope for the best...
+		c.mutex.Lock()
+		c.paths[clientConnID] = returnPath{path: saddr.Path, nextHop: saddr.NextHop}
+		c.mutex.Unlock()
+		saddr.Path = nil // hide it,
+		saddr.NextHop = nil
+	}
+	return n, saddr, nil
 }
 
 func (c *returnPathConn) WriteTo(p []byte, addr net.Addr) (int, error) {
-	if saddr, ok := addr.(*snet.UDPAddr); ok && saddr.Path == nil { // XXX && saddr.IA = localIA
-		c.mutex.RLock()
-		defer c.mutex.RUnlock()
 
-		retPath, ok := c.paths[makeKey(saddr)]
+	saddr := addr.(*udpAddrEx)
+
+	if (saddr.serverConnID == connectionID{}) {
+		serverConnID, err := parseSrcConnectionID(p)
+		if err == nil {
+			saddr.serverConnID = serverConnID
+			c.mutex.Lock()
+			c.clientConnIDs[serverConnID] = saddr.clientConnID
+			c.mutex.Unlock()
+		}
+	}
+
+	if saddr.Path == nil {
+		c.mutex.RLock()
+		retPath, ok := c.paths[saddr.clientConnID]
+		c.mutex.RUnlock()
 		if ok {
 			addr = &snet.UDPAddr{
 				IA:      saddr.IA,
@@ -96,18 +139,62 @@ type returnPath struct {
 	nextHop *net.UDPAddr
 }
 
-type returnPathKey struct {
-	ia   addr.IA
-	ip   [16]byte
-	port int
+type connectionID = [18]byte
+
+func makeConnectionID(id []byte) connectionID {
+	v := connectionID{}
+	copy(v[:], id)
+	return v
 }
 
-func makeKey(addr *snet.UDPAddr) returnPathKey {
-	ip := [16]byte{}
-	copy(ip[:], addr.Host.IP)
-	return returnPathKey{
-		ia:   addr.IA,
-		ip:   ip,
-		port: addr.Host.Port,
+// parseDestConnectionID parses the destination connection ID of a packet.
+func parseDestConnectionID(data []byte, shortHeaderConnIDLen int) (connectionID, error) {
+	if len(data) == 0 {
+		return connectionID{}, io.EOF
 	}
+	isLongHeader := data[0]&0x80 > 0
+	if !isLongHeader {
+		if len(data) < shortHeaderConnIDLen+1 {
+			return connectionID{}, io.EOF
+		}
+		return makeConnectionID(data[1 : 1+shortHeaderConnIDLen]), nil
+	}
+	if len(data) < 6 {
+		return connectionID{}, io.EOF
+	}
+	destConnIDLen := int(data[5])
+	if len(data) < 6+destConnIDLen {
+		return connectionID{}, io.EOF
+	}
+	return makeConnectionID(data[6 : 6+destConnIDLen]), nil
+}
+
+// parseSrcConnectionID parses the source connection ID of a packet.
+// The source connection ID is only availabe on long header packets.
+func parseSrcConnectionID(data []byte) (connectionID, error) {
+	if len(data) == 0 {
+		return connectionID{}, io.EOF
+	}
+	isLongHeader := data[0]&0x80 > 0
+	if !isLongHeader {
+		return connectionID{}, io.EOF
+	}
+	offset := 1
+	offset += 4 // skip version
+	if len(data) < offset+1 {
+		return connectionID{}, io.EOF
+	}
+	destConnIDLen := int(data[offset])
+	offset += 1
+	offset += destConnIDLen
+
+	if len(data) < offset+1 {
+		return connectionID{}, io.EOF
+	}
+	srcConnIDLen := int(data[offset])
+	offset += 1
+	if len(data) < offset+srcConnIDLen {
+		return connectionID{}, io.EOF
+	}
+	return makeConnectionID(data[offset : offset+srcConnIDLen]), nil
 }


### PR DESCRIPTION
The server replies on the path on which the last packet was received.
Previously, this was indexed by the `(IA, IP, port)` tuple of the client, which kind of defeats the point of connection IDs; specifically, this did not work well with the connection setup race that the client does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/162)
<!-- Reviewable:end -->
