### PR TITLE
Fix policy based filter operation in scionutils.policyConn

### DIFF
--- a/ssh/scionutils/policy_conn.go
+++ b/ssh/scionutils/policy_conn.go
@@ -172,8 +172,7 @@ func queryPathsFiltered(ia addr.IA, policy *pathpol.Policy) ([]snet.Path, error)
 	for _, path := range paths {
 		pathSet[path.Fingerprint()] = path
 	}
-	policy.Filter(pathSet)
-	filterPathSlice(&paths, pathSet)
+	filterPathSlice(&paths, policy.Filter(pathSet))
 	return paths, nil
 }
 


### PR DESCRIPTION
The result of the policy based filter operation has been ignored in function queryPathsFiltered (policy_conn.go). There are currently no unit or integration tests for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/169)
<!-- Reviewable:end -->
