### PR TITLE
skip: kludgy SCION browser support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build: scion-bat \
 	scion-imagefetcher scion-imageserver \
 	scion-netcat \
 	scion-sensorfetcher scion-sensorserver \
+	scion-skip \
 	scion-ssh scion-sshd \
 	example-helloworld \
 	example-hellodrkey \
@@ -78,6 +79,10 @@ scion-sensorfetcher:
 .PHONY: scion-sensorserver
 scion-sensorserver:
 	go build -tags=$(TAGS) -o $(BIN)/$@ ./sensorapp/sensorserver/
+
+.PHONY: scion-skip
+scion-skip:
+	go build -tags=$(TAGS) -o $(BIN)/$@ ./skip/
 
 .PHONY: scion-ssh
 scion-ssh:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Sensorapp contains fetcher and server applications for sensor readings, using th
 
 Installation and usage information is available on the [SCION Tutorials web page for sensorapp](https://docs.scionlab.org/content/apps/fetch_sensor_readings.html).
 
+## skip
+
+skip is a very simple local HTTP proxy server for very basic SCION browser support. See the [skip README](skip/README.md) for more information.
 
 ## ssh
 

--- a/_examples/shttp/fileserver/main.go
+++ b/_examples/shttp/fileserver/main.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
+	"github.com/gorilla/handlers"
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 
@@ -29,39 +31,9 @@ func main() {
 	port := flag.Uint("p", 443, "port the server listens on")
 	flag.Parse()
 
-	handler := http.FileServer(http.Dir(""))
-	log.Fatal(shttp.ListenAndServe(fmt.Sprintf(":%d", *port), withLogger(handler), nil))
-}
-
-// withLogger returns a handler that logs requests (after completion) in a simple format:
-//	  <time> <remote address> "<request>" <status code> <size of reply>
-func withLogger(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wrec := &recordingResponseWriter{ResponseWriter: w}
-		h.ServeHTTP(wrec, r)
-
-		log.Printf("%s \"%s %s %s/SCION\" %d %d\n",
-			r.RemoteAddr,
-			r.Method, r.URL, r.Proto,
-			wrec.status, wrec.bytes)
-	})
-}
-
-type recordingResponseWriter struct {
-	http.ResponseWriter
-	status int
-	bytes  int
-}
-
-func (r *recordingResponseWriter) WriteHeader(statusCode int) {
-	r.status = statusCode
-	r.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (r *recordingResponseWriter) Write(b []byte) (int, error) {
-	if r.status == 0 {
-		r.status = http.StatusOK
-	}
-	r.bytes += len(b)
-	return r.ResponseWriter.Write(b)
+	handler := handlers.LoggingHandler(
+		os.Stdout,
+		http.FileServer(http.Dir("")),
+	)
+	log.Fatal(shttp.ListenAndServe(fmt.Sprintf(":%d", *port), handler, nil))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84
+	github.com/gorilla/handlers v1.5.1
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/kormat/fmt15 v0.0.0-20181112140556-ee69fecb2656
 	github.com/kr/pty v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
@@ -173,6 +175,8 @@ github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE0
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/skip/README.md
+++ b/skip/README.md
@@ -1,0 +1,53 @@
+# skip
+
+**skip** (SCION kludge in *p*rowsers, also "ship" in many languages and so fitting
+with the lighthouse/beacon scheme :boat:) is a poor man's browser integration
+for SCION.
+
+skip uses a [Proxy auto-config](https://en.wikipedia.org/wiki/Proxy_auto-config) file
+to forward all requests that are go to a SCION destination to a proxy server,
+running as a (native) binary on the localhost.
+As this mechanism does not let us support a separate protocol identifier nor allow
+looking up whether a name refers to a SCION address, we identify SCION addresses
+as either:
+  * the host name of a SCION host with an appended  pseudo-TLD `.scion`, e.g.
+    `http://www.scionlab.org.scion`, or
+  * a mangled SCION address in the form `<ISD>-<AS id with
+    underscores>-<host>`, e.g. `http://17-ffaa_0_1101-129.132.121.164/`
+
+## Installation
+
+* Build the `scion-skip` binary by running `make scion-skip` (see
+  [Build](../README.md#build) in the main README).
+
+* Install the `skip.pac` as an "Automatic proxy configuration". 
+
+  In Firefox (currently v84.0), navigate to 
+  **Preferences** / **General** / **Network Settings**, enable "Automatic proxy
+  configuration URL" and enter `file://` and the path to the `skip.pac` file
+  (e.g. `file:///home/skipper/scion-apps/skip/skip.pac`).
+
+## Usage
+
+This requires a running SCION endhost stack, i.e. a running SCION dispatcher
+and SCION daemon.  Please refer to '[Running](../../README.md#Running)' in this
+repository's main README and the [SCIONLab tutorials](https://docs.scionlab.org) to get started.
+
+Start `bin/scion-skip` and keep it running in the background.
+
+Enter SCION addresses in the URL bar of your browser, mangled as described above:
+  * [http://www.scionlab.org.scion](http://www.scionlab.org.scion)
+  * [http://17-ffaa_0_1101-129.132.121.164/](http://17-ffaa_0_1101-129.132.121.164/)
+
+## Limitations
+
+* Chrome does not appear to honor the PAC (WPAD) configuration, even when it reads it. Not sure why.
+* Does not support HTTPS
+* Does not support WebSockets (HTTP CONNECT) method
+* Does not allow specifiying the protocol (e.g. as
+  `scion+http://www.scionlab.org`) but instead uses a kludgy pseudo-TLD to
+  identify SCION hosts.
+
+Obviously this is not great, but hey, it's a start. Some inspiration for how to
+to build something more advanced can be found in this extensions for the gopher
+protocol, [OverbiteNX](https://github.com/classilla/overbitenx).

--- a/skip/README.md
+++ b/skip/README.md
@@ -4,9 +4,9 @@
 with the lighthouse/beacon scheme :boat:) is a poor man's browser integration
 for SCION.
 
-skip uses a [Proxy auto-config](https://en.wikipedia.org/wiki/Proxy_auto-config) file
-to forward all requests that are go to a SCION destination to a proxy server,
-running as a (native) binary on the localhost.
+skip uses a [Proxy auto-config](https://en.wikipedia.org/wiki/Proxy_auto-config)
+file to forward all requests with a SCION destination to a proxy server running
+as a (native) binary on localhost.
 As this mechanism does not let us support a separate protocol identifier nor allow
 looking up whether a name refers to a SCION address, we identify SCION addresses
 as either:
@@ -20,9 +20,9 @@ as either:
 * Build the `scion-skip` binary by running `make scion-skip` (see
   [Build](../README.md#build) in the main README).
 
-* Install the `skip.pac` as an "Automatic proxy configuration". 
+* Install the `skip.pac` as an "Automatic proxy configuration".
 
-  In Firefox (currently v84.0), navigate to 
+  In Firefox (currently v84.0), navigate to
   **Preferences** / **General** / **Network Settings**, enable "Automatic proxy
   configuration URL" and enter `file://` and the path to the `skip.pac` file
   (e.g. `file:///home/skipper/scion-apps/skip/skip.pac`).

--- a/skip/main.go
+++ b/skip/main.go
@@ -1,0 +1,98 @@
+// Copyright 2020 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/handlers"
+	"github.com/netsec-ethz/scion-apps/pkg/shttp"
+)
+
+var (
+	mungedScionAddr = regexp.MustCompile(`^(\d+)-([_\dA-Fa-f]+)-(.*)$`)
+)
+
+const (
+	mungedScionAddrIAIndex   = 1
+	mungedScionAddrASIndex   = 2
+	mungedScionAddrHostIndex = 3
+)
+
+func main() {
+	transport := shttp.NewRoundTripper(&tls.Config{InsecureSkipVerify: true}, nil)
+	defer transport.Close()
+	proxy := &ProxyHandler{
+		Transport: transport,
+	}
+
+	server := &http.Server{
+		Addr:    "localhost:8888",
+		Handler: handlers.LoggingHandler(os.Stdout, proxy),
+	}
+	log.Fatal(server.ListenAndServe())
+}
+
+type ProxyHandler struct {
+	Transport http.RoundTripper
+}
+
+func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+
+	req.Host = demunge(req.Host)
+	req.URL.Scheme = "https"
+	req.URL.Host = req.Host
+
+	resp, err := h.Transport.RoundTrip(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeader(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// demunge reverts the host name to a proper SCION address, from the format
+// that had been entered in the browser.
+func demunge(host string) string {
+	parts := mungedScionAddr.FindStringSubmatch(host)
+	if parts != nil {
+		// directly apply mangling as inMangleSCIONAddr
+		return fmt.Sprintf("[%s-%s,%s]",
+			parts[mungedScionAddrIAIndex],
+			strings.ReplaceAll(parts[mungedScionAddrASIndex], "_", ":"),
+			parts[mungedScionAddrHostIndex],
+		)
+	} else {
+		return strings.TrimSuffix(host, ".scion")
+	}
+}

--- a/skip/skip.pac
+++ b/skip/skip.pac
@@ -1,0 +1,8 @@
+function FindProxyForURL(url, host)
+{
+  let mungedScionAddr = /^\d+-[-_.\dA-Fa-f]+$/
+  if (host.match(mungedScionAddr) != null || shExpMatch(host, "*.scion")) {
+	  return "PROXY localhost:8888";
+  }
+  return "DIRECT";
+}


### PR DESCRIPTION
**skip** (SCION kludge in *p*rowsers, also "ship" in many languages and so fitting with the lighthouse/beacon scheme :boat:) is a poor man's browser integration for SCION.

skip uses a [Proxy auto-config](https://en.wikipedia.org/wiki/Proxy_auto-config) file to forward all requests that are go to a SCION destination to a proxy server, running as a (native) binary on the localhost. As this mechanism does not let us support a separate protocol identifier nor allow looking up whether a name refers to a SCION address, we identify SCION addresses as either:
  * the host name of a SCION host with an appended  pseudo-TLD `.scion`, e.g. `http://www.scionlab.org.scion`, or
  * a mangled SCION address in the form `<ISD>-<AS id with underscores>-<host>`, e.g. `http://17-ffaa_0_1101-129.132.121.164/`
 
To make links and redirects work as intended, i.e. keep using SCION, the proxy replaces matching URLs in the response with these "munged" addresses.

Limitations:
* Chrome does not appear to honor the PAC (WPAD) configuration, even when it reads it. Not sure why.
* Does not support HTTPS
* Does not support WebSockets (HTTP CONNECT) method
* Does not allow specifiying the protocol (e.g. as `scion+http://www.scionlab.org`) but instead uses a kludgy pseudo-TLD to
  identify SCION hosts.

Obviously this is not great, but hey, it's a start. Some inspiration for how to to build something more advanced can be found in this extensions for the gopher protocol, [OverbiteNX](https://github.com/classilla/overbitenx).


Also in this PR:
*  use the gorilla/handlers library as logging middleware in HTTP servers, in the new skip proxy server as well as in _examples/shttp/fileserver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/181)
<!-- Reviewable:end -->
