### PR TITLE
appnet: fix QueryPaths error handling

### DIFF
--- a/pkg/appnet/path_selection.go
+++ b/pkg/appnet/path_selection.go
@@ -17,6 +17,7 @@ package appnet
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -110,8 +111,11 @@ func QueryPaths(ia addr.IA) ([]snet.Path, error) {
 		return nil, nil
 	} else {
 		paths, err := DefNetwork().PathQuerier.Query(context.Background(), ia)
-		if err != nil || len(paths) == 0 {
+		if err != nil {
 			return nil, err
+		}
+		if len(paths) == 0 {
+			return nil, errors.New("no path available")
 		}
 		paths = filterDuplicates(paths)
 		return paths, nil


### PR DESCRIPTION
An empty non-error response could lead to no path being set by SetDefaultPath.
Explicitly return an error if the no path was found in QueryPaths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/186)
<!-- Reviewable:end -->
