### PR TITLE
constant bit rate tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ all: lint build
 
 build: scion-bat \
 	scion-bwtestclient scion-bwtestserver \
-	scion-cbrtester \
 	scion-burster \
+	scion-cbrtester \
 	scion-imagefetcher scion-imageserver \
 	scion-netcat \
 	scion-sensorfetcher scion-sensorserver \
@@ -63,13 +63,13 @@ scion-bwtestclient:
 scion-bwtestserver:
 	go build -tags=$(TAGS) -o $(BIN)/$@ ./bwtester/bwtestserver/
 
-.PHONY: scion-cbrtester
-scion-cbrtester:
-	go build -tags=$(TAGS) -o $(BIN)/$@ ./cbrtester/
-
 .PHONY: scion-burster
 scion-burster:
 	go build -tags=$(TAGS) -o $(BIN)/$@ ./burster/
+
+.PHONY: scion-cbrtester
+scion-cbrtester:
+	go build -tags=$(TAGS) -o $(BIN)/$@ ./cbrtester/
 
 .PHONY: scion-imagefetcher
 scion-imagefetcher:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all: lint build
 
 build: scion-bat \
 	scion-bwtestclient scion-bwtestserver \
+	scion-cbrtester \
 	scion-imagefetcher scion-imageserver \
 	scion-netcat \
 	scion-sensorfetcher scion-sensorserver \
@@ -60,6 +61,10 @@ scion-bwtestclient:
 .PHONY: scion-bwtestserver
 scion-bwtestserver:
 	go build -tags=$(TAGS) -o $(BIN)/$@ ./bwtester/bwtestserver/
+
+.PHONY: scion-cbrtester
+scion-cbrtester:
+	go build -tags=$(TAGS) -o $(BIN)/$@ ./cbrtester/
 
 .PHONY: scion-imagefetcher
 scion-imagefetcher:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all: lint build
 build: scion-bat \
 	scion-bwtestclient scion-bwtestserver \
 	scion-cbrtester \
+	scion-burster \
 	scion-imagefetcher scion-imageserver \
 	scion-netcat \
 	scion-sensorfetcher scion-sensorserver \
@@ -65,6 +66,10 @@ scion-bwtestserver:
 .PHONY: scion-cbrtester
 scion-cbrtester:
 	go build -tags=$(TAGS) -o $(BIN)/$@ ./cbrtester/
+
+.PHONY: scion-burster
+scion-burster:
+	go build -tags=$(TAGS) -o $(BIN)/$@ ./burster/
 
 .PHONY: scion-imagefetcher
 scion-imagefetcher:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ The bandwidth testing application bwtester enables a variety of bandwidth tests 
 Installation and usage information is available on the [SCION Tutorials web page for bwtester](https://docs.scionlab.org/content/apps/bwtester.html).
 
 
+## burster
+
+A tool that helps identifying problems with border routers dropping packets. It can also be used to add load to border routers. [README](burster/README.md).
+
+## cbrtester
+
+A tool intended to detect conditions on border routers, where packets are delayed more than the ordinary. [README](cbrtester/README.md).
 ## camerapp
 
 Camerapp contains image fetcher and server applications, using the SCION network. Documentation of the code is available in the [camerapp README](camerapp/README.md).

--- a/burster/README.md
+++ b/burster/README.md
@@ -1,0 +1,6 @@
+# Burster
+
+Sends and receives gapless bursts of packets in 5s intervals.
+
+The client chooses the packet size, the burst size and the path, and the server
+prints out the number of received packets per burst. If any loss occurred then the number of received packets will be lower than the burst size set on the client.

--- a/burster/burster.go
+++ b/burster/burster.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	port := flag.Uint("port", 0, "[Server] local port to listen on")
+	port := flag.Uint("port", 0, "[Server] Local port to listen on")
 	size := flag.Uint("size", 300, "[Client] Burst size")
 	payload := flag.Uint("payload", 100, "[Client] Size of each packet in bytes")
 	interactive := flag.Bool("interactive", false, "[Client] Select the path interactively")

--- a/burster/burster.go
+++ b/burster/burster.go
@@ -105,7 +105,7 @@ func runClient(address string, burstSize int, payloadSize int, interactive bool)
 
 		fmt.Println("Sleeping...")
 		
-		// Sent reset messages (duplicate in case of loss)
+		// Send reset message twice
 		time.Sleep(500 * time.Millisecond)
 
 		buffer[0] = 2

--- a/burster/burster.go
+++ b/burster/burster.go
@@ -132,7 +132,7 @@ func runServer(port int) error {
 		return serrors.WrapStr("can't listen:", err)
 	}
 	defer listener.Close()
-	fmt.Println(listener.LocalAddr())
+	fmt.Printf("%v,%v\n", appnet.DefNetwork().IA, listener.LocalAddr())
 
 	buffer := make([]byte, 16*1024)
 	receivedCount := 0

--- a/burster/burster.go
+++ b/burster/burster.go
@@ -104,7 +104,7 @@ func runClient(address string, burstSize int, payloadSize int, interactive bool)
 		}
 
 		fmt.Println("Sleeping...")
-		
+
 		// Send reset message twice
 		time.Sleep(500 * time.Millisecond)
 

--- a/burster/burster.go
+++ b/burster/burster.go
@@ -1,0 +1,156 @@
+// Copyright 2020 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// burster application
+// For more documentation on the application see:
+// https://github.com/netsec-ethz/scion-apps/blob/master/README.md
+// https://github.com/netsec-ethz/scion-apps/blob/master/bwtester/README.md
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/snet"
+
+	"github.com/netsec-ethz/scion-apps/pkg/appnet"
+)
+
+func main() {
+	port := flag.Uint("port", 0, "[Server] local port to listen on")
+	size := flag.Uint("size", 300, "[Client] Burst size")
+	payload := flag.Uint("payload", 100, "[Client] Size of each packet in bytes")
+	interactive := flag.Bool("interactive", false, "[Client] Select the path interactively")
+
+	remoteAddr := flag.String("remote", "", "[Client] Remote (i.e. the server's) SCION Address (e.g. 17-ffaa:1:1,[127.0.0.1]:12345)")
+	flag.Parse()
+
+	if (*port > 0) == (len(*remoteAddr) > 0) {
+		fmt.Println("Either specify -port for server or -remote for client")
+		os.Exit(1)
+	}
+
+	var err error
+	if *port > 0 {
+		err = runServer(int(*port))
+	} else {
+		err = runClient(*remoteAddr, int(*size), int(*payload), *interactive)
+	}
+	if err != nil {
+		fmt.Println("err", err)
+		os.Exit(1)
+	}
+}
+
+func runClient(address string, burstSize int, payloadSize int, interactive bool) error {
+	addr, err := appnet.ResolveUDPAddr(address)
+	if err != nil {
+		return err
+	}
+	var path snet.Path
+	if interactive {
+		path, err = appnet.ChoosePathInteractive(addr.IA)
+		if err != nil {
+			return err
+		}
+		appnet.SetPath(addr, path)
+	} else {
+		paths, err := appnet.QueryPaths(addr.IA)
+		if err != nil {
+			return err
+		}
+		path = paths[0]
+	}
+
+	conn, err := appnet.DialAddr(addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	fmt.Printf("Running client using payload size %v and burst size %v via %v\n", payloadSize, burstSize, path)
+
+	if err != nil {
+		return err
+	}
+
+	buffer := make([]byte, payloadSize)
+
+	for {
+		fmt.Println("Sending burst")
+		buffer[0] = 1
+
+		for i := 0; i < burstSize; i++ {
+			_, err := conn.Write(buffer)
+
+			if err != nil {
+				fmt.Println(err)
+			}
+		}
+
+		fmt.Println("Sleeping...")
+		
+		// Sent reset messages (duplicate in case of loss)
+		time.Sleep(500 * time.Millisecond)
+
+		buffer[0] = 2
+		_, err := conn.Write(buffer)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		time.Sleep(4 * time.Second)
+
+		buffer[0] = 2
+		_, errr := conn.Write(buffer)
+		if errr != nil {
+			fmt.Println(errr)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func runServer(port int) error {
+	listener, err := appnet.ListenPort(uint16(port))
+	if err != nil {
+		return serrors.WrapStr("can't listen:", err)
+	}
+	defer listener.Close()
+	fmt.Println(listener.LocalAddr())
+
+	buffer := make([]byte, 16*1024)
+	receivedCount := 0
+	reset := true
+	for {
+		count, _, err := listener.ReadFrom(buffer)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		if !reset && count > 0 && buffer[0] == 2 {
+			fmt.Printf("Received %v packets in burst\n", receivedCount)
+			receivedCount = 0
+			reset = true
+		} else if count > 0 && buffer[0] != 2 {
+			receivedCount += 1
+			reset = false
+		}
+	}
+}

--- a/cbrtester/README.md
+++ b/cbrtester/README.md
@@ -1,0 +1,6 @@
+# Constant Bit Rate Tester
+
+Sends at a constant rate using the specified path.
+
+The client chooses the packet size, the rate and the path, and the server
+prints out the receive rate and stalls (freezes) if any are detected.

--- a/cbrtester/cbrtester.go
+++ b/cbrtester/cbrtester.go
@@ -116,7 +116,7 @@ func runServer(port int, timeout int64) error {
 		return serrors.WrapStr("can't listen:", err)
 	}
 	defer listener.Close()
-	fmt.Println(listener.LocalAddr())
+	fmt.Printf("%v,%v\n", appnet.DefNetwork().IA, listener.LocalAddr())
 
 	lastReceived := time.Now().Add(time.Hour * 24 * 3)
 

--- a/cbrtester/cbrtester.go
+++ b/cbrtester/cbrtester.go
@@ -82,7 +82,7 @@ func runClient(address string, desiredThroughput int, payloadSize int, interacti
 	defer conn.Close()
 	fmt.Printf("Running client using payload size %v and rate %v via %v\n", payloadSize, desiredThroughput, path)
 
-	numberOfPacketsPerSecond := 8 * desiredThroughput / payloadSize
+	numberOfPacketsPerSecond := desiredThroughput / 8 / payloadSize
 	interval := time.Duration(float64(time.Second) / float64(numberOfPacketsPerSecond))
 
 	buffer := make([]byte, payloadSize)

--- a/cbrtester/cbrtester.go
+++ b/cbrtester/cbrtester.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	port := flag.Uint("port", 0, "[Server] local port to listen on")
+	port := flag.Uint("port", 0, "[Server] Local port to listen on")
 	timeout := flag.Uint("timeout", 100, "[Server] Size of gap between subsequent packets that is considered a freeze (in ms)")
 
 	bw := flag.Uint("bw", 1024*1024, "[Client] Rate to send at (in bps)")
@@ -118,7 +118,7 @@ func runServer(port int, timeout int64) error {
 	defer listener.Close()
 	fmt.Printf("%v,%v\n", appnet.DefNetwork().IA, listener.LocalAddr())
 
-	lastReceived := time.Now().Add(time.Hour * 24 * 3)
+	lastReceived := time.Now().Add(999 * time.Hour) // avoids elapsed > timeout in the 1st iter
 
 	buffer := make([]byte, 16*1024)
 

--- a/cbrtester/cbrtester.go
+++ b/cbrtester/cbrtester.go
@@ -35,7 +35,7 @@ func main() {
 	port := flag.Uint("port", 0, "[Server] local port to listen on")
 	timeout := flag.Uint("timeout", 100, "[Server] Size of gap between subsequent packets that is considered a freeze (in ms)")
 
-	bw := flag.Uint("bw", 1024 * 1024, "[Client] Rate to send at (in bps)")
+	bw := flag.Uint("bw", 1024*1024, "[Client] Rate to send at (in bps)")
 	payload := flag.Uint("payload", 100, "[Client] Size of each packet in bytes")
 	interactive := flag.Bool("interactive", false, "[Client] Select the path interactively")
 	remoteAddr := flag.String("remote", "", "[Client] Remote (i.e. the server's) SCION Address (e.g. 17-ffaa:1:1,[127.0.0.1]:12345)")
@@ -89,7 +89,7 @@ func runClient(address string, desiredThroughput int, payloadSize int, interacti
 	numberOfPacketsPerSecond := float64(desiredThroughput) / 8. / float64(payloadSize)
 	interval := time.Duration(float64(time.Second) / numberOfPacketsPerSecond)
 
-	fmt.Printf("Sending %v packets per second with a gap of %v\n", numberOfPacketsPerSecond, interval);
+	fmt.Printf("Sending %v packets per second with a gap of %v\n", numberOfPacketsPerSecond, interval)
 
 	buffer := make([]byte, payloadSize)
 	copy(buffer, []byte("cbrtester")) // allow easy identification of packets

--- a/cbrtester/cbrtester.go
+++ b/cbrtester/cbrtester.go
@@ -32,7 +32,7 @@ import (
 
 func main() {
 	port := flag.Uint("port", 0, "[Server] local port to listen on")
-	bw := flag.Uint("bw", (1024*1024)/8, "[Client] Rate to send at (in bps)")
+	bw := flag.Uint("bw", 1024 * 1024, "[Client] Rate to send at (in bps)")
 	payload := flag.Uint("payload", 100, "[Client] Size of each packet in bytes")
 	interactive := flag.Bool("interactive", false, "[Client] Select the path interactively")
 


### PR DESCRIPTION
(adapted from previous work of @jonasgessner)

A simple application that helps identify problems with delays in the retransmission along a path, for example, if there is the suspicion that certain BR along a path delays packets for too long, too frequently.

This could be a baseline for a more complex application that would tell where the delays have happened, à la `traceroute`, but with a specified rate and payload size.

There is also a `burster` tool that helps identifying problems with packet drops at BRs (from @jonasgessner)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/191)
<!-- Reviewable:end -->
