### PR TITLE
appquic: silence quic-go warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   integration:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202107-02
 
     steps:
       - checkout
@@ -92,9 +92,6 @@ jobs:
       - run:
           name: Integration tests
           command: |
-            # XXX: hack, don't build skip here, needs go-1.16, currently this runs on go-1.15.
-            # As there are currently no integration tests for scion-skip, we don't need it here.
-            sed -i '/^\s*scion-skip\s*\\$/d' Makefile
             make integration
       - store_artifacts:
           path: /tmp/scion-apps-integration/


### PR DESCRIPTION
quic-go wants to set the read buffer size for the Conn, but snet and the
dispatcher setup does not support this.
Faking the operations to set the read buffer size does not work, as
quic-go also checks directly with a system call whether the operation
was successful.
As a hacky workaround, we simply silence the logger during the quic.Dial
and quic.Listen calls.

Closes #201

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/202)
<!-- Reviewable:end -->
