### PR TITLE
bwtester: tests and fixes for parameter parsing

### DIFF
--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -47,10 +47,6 @@ const (
 	WildcardChar            = "?"
 )
 
-var (
-	InferedPktSize int64
-)
-
 func prepareAESKey() []byte {
 	key := make([]byte, 16)
 	n, err := rand.Read(key)
@@ -81,7 +77,7 @@ func printUsage() {
 // Input format (time duration,packet size,number of packets,target bandwidth), no spaces, question mark ? is wildcard
 // The value of the wildcard is computed from the other values, if more than one wildcard is used,
 // all but the last one are set to the defaults values
-func parseBwtestParameters(s string) BwtestParameters {
+func parseBwtestParameters(s string, defaultPktSize int64) (BwtestParameters, error) {
 	if !strings.Contains(s, ",") {
 		// Using simple bandwidth setting with all defaults except bandwidth
 		s = "?,?,?," + s
@@ -102,7 +98,7 @@ func parseBwtestParameters(s string) BwtestParameters {
 	if a[0] == WildcardChar {
 		wildcards -= 1
 		if wildcards == 0 {
-			a2 = getPacketSize(a[1])
+			a2 = getPacketSize(a[1], defaultPktSize)
 			a3 = getPacketCount(a[2])
 			a4 = parseBandwidth(a[3])
 			a1 = (a2 * 8 * a3) / a4
@@ -131,10 +127,10 @@ func parseBwtestParameters(s string) BwtestParameters {
 			a4 = parseBandwidth(a[3])
 			a2 = (a4 * a1) / (a3 * 8)
 		} else {
-			a2 = InferedPktSize
+			a2 = int64(defaultPktSize)
 		}
 	} else {
-		a2 = getPacketSize(a[1])
+		a2 = getPacketSize(a[1], defaultPktSize)
 	}
 	if a[2] == WildcardChar {
 		wildcards -= 1
@@ -155,10 +151,15 @@ func parseBwtestParameters(s string) BwtestParameters {
 	} else {
 		a4 = parseBandwidth(a[3])
 		// allow a deviation of up to one packet per 1 second interval, since we do not send half-packets
-		if a2*a3*8/a1 > a4+a2*a1 || a2*a3*8/a1 < a4-a2*a1 {
-			Check(fmt.Errorf("Computed target bandwidth does not match parameters, "+
-				"use wildcard or specify correct bandwidth, expected %d, provided %d",
-				a2*a3*8/a1, a4))
+		expected := a2 * a3 * 8 / a1
+		leeway := 8 * a2
+		lo := expected - leeway
+		hi := expected + leeway
+		if a4 < lo || a4 > hi {
+			return BwtestParameters{},
+				fmt.Errorf("Computed target bandwidth does not match parameters, "+
+					"use wildcard or specify correct bandwidth, expected %d-%d, provided %d",
+					lo, hi, a4)
 		}
 	}
 	key := prepareAESKey()
@@ -168,7 +169,7 @@ func parseBwtestParameters(s string) BwtestParameters {
 		NumPackets:     a3,
 		PrgKey:         key,
 		Port:           0,
-	}
+	}, nil
 }
 
 func parseBandwidth(bw string) int64 {
@@ -223,11 +224,11 @@ func getDuration(duration string) int64 {
 	return a1
 }
 
-func getPacketSize(size string) int64 {
+func getPacketSize(size string, defaultPktSize int64) int64 {
 	a2, err := strconv.ParseInt(size, 10, 64)
 	if err != nil {
-		fmt.Printf("Invalid packet size %v provided, using default value %d\n", a2, InferedPktSize)
-		a2 = InferedPktSize
+		fmt.Printf("Invalid packet size %v provided, using default value %d\n", a2, defaultPktSize)
+		a2 = defaultPktSize
 	}
 
 	if a2 < MinPacketSize {
@@ -330,24 +331,25 @@ func main() {
 		context.TODO(), "udp", clientDCAddr, serverDCAddr, addr.SvcNone)
 	Check(err)
 
+	// use default packet size when within same AS and pathEntry is not set
+	inferedPktSize := int64(DefaultPktSize)
 	// update default packet size to max MTU on the selected path
 	if path != nil {
-		InferedPktSize = int64(path.Metadata().MTU)
-	} else {
-		// use default packet size when within same AS and pathEntry is not set
-		InferedPktSize = DefaultPktSize
+		inferedPktSize = int64(path.Metadata().MTU)
 	}
 	if !flagset["cs"] && flagset["sc"] { // Only one direction set, used same for reverse
 		clientBwpStr = serverBwpStr
 		fmt.Println("Only sc parameter set, using same values for cs")
 	}
-	clientBwp = parseBwtestParameters(clientBwpStr)
+	clientBwp, err = parseBwtestParameters(clientBwpStr, inferedPktSize)
+	Check(err)
 	clientBwp.Port = uint16(clientDCAddr.Port)
 	if !flagset["sc"] && flagset["cs"] { // Only one direction set, used same for reverse
 		serverBwpStr = clientBwpStr
 		fmt.Println("Only cs parameter set, using same values for sc")
 	}
-	serverBwp = parseBwtestParameters(serverBwpStr)
+	serverBwp, err = parseBwtestParameters(serverBwpStr, inferedPktSize)
+	Check(err)
 	serverBwp.Port = uint16(serverDCAddr.Host.Port)
 	fmt.Println("\nTest parameters:")
 	fmt.Println("clientDCAddr -> serverDCAddr", clientDCAddr, "->", serverDCAddr)

--- a/bwtester/bwtestclient/bwtestclient_test.go
+++ b/bwtester/bwtestclient/bwtestclient_test.go
@@ -1,0 +1,144 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseParameters(t *testing.T) {
+	defaultDuration := time.Second * DefaultDuration // XXX should be defined as Duration
+
+	cases := []struct {
+		name               string
+		input              string
+		inferedPktSize     int // input, value inferred from path MTU
+		expectedDuration   time.Duration
+		expectedPacketSize int
+		expectedNumPackets int
+		expectErr          bool
+	}{
+		{
+			name:               "bw 1Mbps",
+			input:              "1Mbps",
+			inferedPktSize:     1400,
+			expectedDuration:   defaultDuration,
+			expectedPacketSize: 1400,
+			expectedNumPackets: 267,
+		},
+		{
+			name:               "bw 10Mbps",
+			input:              "10Mbps",
+			inferedPktSize:     1400,
+			expectedDuration:   defaultDuration,
+			expectedPacketSize: 1400,
+			expectedNumPackets: 2678,
+		},
+		{
+			name:               "1s, 1Mbps",
+			input:              "1,?,?,1Mbps",
+			inferedPktSize:     1400,
+			expectedDuration:   time.Second,
+			expectedPacketSize: 1400,
+			expectedNumPackets: 89,
+		},
+		{
+			name:               "1s, 1Mbps",
+			input:              "1,?,?,1Mbps",
+			inferedPktSize:     1400,
+			expectedDuration:   time.Second,
+			expectedPacketSize: 1400,
+			expectedNumPackets: 89,
+		},
+		{
+			name:               "computed bw",
+			input:              "1,1000,1000,?",
+			expectedDuration:   time.Second,
+			expectedPacketSize: 1000,
+			expectedNumPackets: 1000,
+		},
+		{
+			name:               "computed bw, default pkt size",
+			input:              "1,?,1000,?",
+			inferedPktSize:     1000,
+			expectedDuration:   time.Second,
+			expectedPacketSize: 1000,
+			expectedNumPackets: 1000,
+		},
+		{
+			name:               "redundant bw",
+			input:              "1,1000,1000,8Mbps",
+			inferedPktSize:     1000,
+			expectedDuration:   time.Second,
+			expectedPacketSize: 1000,
+			expectedNumPackets: 1000,
+		},
+		{
+			name:               "redundant bw, longer duration",
+			input:              "10,125,10,1000bps",
+			inferedPktSize:     125,
+			expectedDuration:   10 * time.Second,
+			expectedPacketSize: 125,
+			expectedNumPackets: 10,
+		},
+		{
+			name:               "redundant bw, plus one packet per second",
+			input:              "10,125,10,2000bps", // should accept +1 packet/s, so +8*125B == +1000b
+			inferedPktSize:     125,
+			expectedDuration:   10 * time.Second,
+			expectedPacketSize: 125,
+			expectedNumPackets: 10,
+		},
+		{
+			name:               "redundant bw, minus one packet per second",
+			input:              "10,125,10,1bps", // should accept -1 packet/s, so -8*125B == -1000b
+			inferedPktSize:     125,
+			expectedDuration:   10 * time.Second,
+			expectedPacketSize: 125,
+			expectedNumPackets: 10,
+		},
+		{
+			name:      "conflicting bw",
+			input:     "1,1000,1000,1Mbps", // actual: 8Mbps
+			expectErr: true,
+		},
+		{
+			name:               "computed packet size",
+			input:              "3,?,3000,8Mbps",
+			inferedPktSize:     100,
+			expectedDuration:   3 * time.Second,
+			expectedPacketSize: 1000,
+			expectedNumPackets: 3000,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ret, err := parseBwtestParameters(c.input, int64(c.inferedPktSize))
+			if c.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, c.expectedDuration, ret.BwtestDuration, "duration")
+				assert.Equal(t, int64(c.expectedPacketSize), ret.PacketSize, "packet size")
+				assert.Equal(t, int64(c.expectedNumPackets), ret.NumPackets, "num packets")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3
 	github.com/scionproto/scion v0.6.1-0.20210929154253-764d6e2afe47
 	github.com/smartystreets/goconvey v1.6.4
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1


### PR DESCRIPTION
Add tests for `parseBwtestParameters`, with small changes to function
interface to allow calling this from the tests.
Fix discrepancy in computation of bandwidth from other parameters which
had previously led to valid command line parameters to be rejected (for
example `1,?,?,1M`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/205)
<!-- Reviewable:end -->
