### PR TITLE
bwtester: simplification, cleanup

### DIFF
--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -22,13 +22,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -103,7 +104,7 @@ func parseBwtestParameters(s string, defaultPktSize int64) (BwtestParameters, er
 			a4 = parseBandwidth(a[3])
 			a1 = (a2 * 8 * a3) / a4
 			if time.Second*time.Duration(a1) > MaxDuration {
-				fmt.Printf("Duration is exceeding MaxDuration: %v > %v, using default value %d\n",
+				fmt.Printf("Duration exceeds max: %v > %v, using default value %d\n",
 					a1, MaxDuration/time.Second, DefaultDuration)
 				fmt.Println("Target bandwidth might no be reachable with that parameter.")
 				a1 = DefaultDuration
@@ -216,10 +217,8 @@ func getDuration(duration string) int64 {
 		fmt.Printf("Invalid duration %v provided, using default value %d\n", a1, DefaultDuration)
 		a1 = DefaultDuration
 	}
-	d := time.Second * time.Duration(a1)
-	if d > MaxDuration {
-		Check(fmt.Errorf("Duration is exceeding MaxDuration: %d > %d", a1, MaxDuration/time.Second))
-		a1 = DefaultDuration
+	if time.Second*time.Duration(a1) > MaxDuration {
+		Check(fmt.Errorf("Duration exceeds max: %d > %d", a1, MaxDuration/time.Second))
 	}
 	return a1
 }
@@ -252,23 +251,10 @@ func getPacketCount(count string) int64 {
 func main() {
 	var (
 		serverCCAddrStr string
-		serverCCAddr    *snet.UDPAddr
-		// Control channel connection
-		CCConn *snet.Conn
-		// Data channel connection
-		DCConn *snet.Conn
-
-		clientBwpStr string
-		clientBwp    BwtestParameters
-		serverBwpStr string
-		serverBwp    BwtestParameters
-		interactive  bool
-		pathAlgo     string
-
-		err   error
-		tzero time.Time // initialized to "zero" time
-
-		receiveDone sync.Mutex // used to signal when the HandleDCConnReceive goroutine has completed
+		clientBwpStr    string
+		serverBwpStr    string
+		interactive     bool
+		pathAlgo        string
 	)
 
 	flag.Usage = printUsage
@@ -286,16 +272,15 @@ func main() {
 	if flag.NFlag() == 0 {
 		// no flag was set, only print usage and exit
 		printUsage()
-		os.Exit(0)
+		os.Exit(2)
 	}
-
-	if len(serverCCAddrStr) > 0 {
-		serverCCAddr, err = appnet.ResolveUDPAddr(serverCCAddrStr)
-		Check(err)
-	} else {
+	if len(serverCCAddrStr) == 0 {
 		printUsage()
-		Check(fmt.Errorf("Error, server address needs to be specified with -s"))
+		fmt.Println("\nServer address needs to be specified with -s")
+		os.Exit(2)
 	}
+	serverCCAddr, err := appnet.ResolveUDPAddr(serverCCAddrStr)
+	Check(err)
 
 	var path snet.Path
 	if interactive {
@@ -315,22 +300,6 @@ func main() {
 		appnet.SetPath(serverCCAddr, path)
 	}
 
-	CCConn, err = appnet.DialAddr(serverCCAddr)
-	Check(err)
-
-	// get the port used by clientCC after it bound to the dispatcher (because it might be 0)
-	clientCCAddr := CCConn.LocalAddr().(*net.UDPAddr)
-	// Address of client data channel (DC)
-	clientDCAddr := &net.UDPAddr{IP: clientCCAddr.IP, Port: clientCCAddr.Port + 1}
-	// Address of server data channel (DC)
-	serverDCAddr := serverCCAddr.Copy()
-	serverDCAddr.Host.Port = serverCCAddr.Host.Port + 1
-
-	// Data channel connection
-	DCConn, err = appnet.DefNetwork().Dial(
-		context.TODO(), "udp", clientDCAddr, serverDCAddr, addr.SvcNone)
-	Check(err)
-
 	// use default packet size when within same AS and pathEntry is not set
 	inferedPktSize := int64(DefaultPktSize)
 	// update default packet size to max MTU on the selected path
@@ -341,191 +310,224 @@ func main() {
 		clientBwpStr = serverBwpStr
 		fmt.Println("Only sc parameter set, using same values for cs")
 	}
-	clientBwp, err = parseBwtestParameters(clientBwpStr, inferedPktSize)
+	clientBwp, err := parseBwtestParameters(clientBwpStr, inferedPktSize)
 	Check(err)
-	clientBwp.Port = uint16(clientDCAddr.Port)
 	if !flagset["sc"] && flagset["cs"] { // Only one direction set, used same for reverse
 		serverBwpStr = clientBwpStr
 		fmt.Println("Only cs parameter set, using same values for sc")
 	}
-	serverBwp, err = parseBwtestParameters(serverBwpStr, inferedPktSize)
+	serverBwp, err := parseBwtestParameters(serverBwpStr, inferedPktSize)
 	Check(err)
-	serverBwp.Port = uint16(serverDCAddr.Host.Port)
 	fmt.Println("\nTest parameters:")
-	fmt.Println("clientDCAddr -> serverDCAddr", clientDCAddr, "->", serverDCAddr)
 	fmt.Printf("client->server: %d seconds, %d bytes, %d packets\n",
 		int(clientBwp.BwtestDuration/time.Second), clientBwp.PacketSize, clientBwp.NumPackets)
 	fmt.Printf("server->client: %d seconds, %d bytes, %d packets\n",
 		int(serverBwp.BwtestDuration/time.Second), serverBwp.PacketSize, serverBwp.NumPackets)
 
-	t := time.Now()
-	expFinishTimeSend := t.Add(serverBwp.BwtestDuration + MaxRTT + GracePeriodSend)
-	expFinishTimeReceive := t.Add(clientBwp.BwtestDuration + MaxRTT + StragglerWaitPeriod)
-	res := BwtestResult{
-		NumPacketsReceived: -1,
-		CorrectlyReceived:  -1,
-		IPAvar:             -1,
-		IPAmin:             -1,
-		IPAavg:             -1,
-		IPAmax:             -1,
-		PrgKey:             clientBwp.PrgKey,
-		ExpectedFinishTime: expFinishTimeReceive,
+	clientRes, serverRes, err := runBwtest(serverCCAddr, clientBwp, serverBwp)
+	Check(err)
+
+	fmt.Println("\nS->C results")
+	printBwtestResult(serverBwp, clientRes)
+	fmt.Println("\nC->S results")
+	printBwtestResult(clientBwp, serverRes)
+}
+
+// runBwtest runs the bandwidth test with the given parameters against the server at serverCCAddr.
+func runBwtest(serverCCAddr *snet.UDPAddr,
+	clientBwp, serverBwp BwtestParameters) (clientRes, serverRes BwtestResult, err error) {
+
+	// Control channel connection
+	ccConn, err := appnet.DialAddr(serverCCAddr)
+	if err != nil {
+		return
 	}
-	var resLock sync.Mutex
-	if expFinishTimeReceive.Before(expFinishTimeSend) {
-		// The receiver will close the DC connection, so it will wait long enough until the
-		// sender is also done
-		res.ExpectedFinishTime = expFinishTimeSend
+	clientCCAddr := ccConn.LocalAddr().(*net.UDPAddr)
+
+	// Address of client data channel (DC)
+	clientDCAddr := &net.UDPAddr{IP: clientCCAddr.IP, Port: clientCCAddr.Port + 1}
+	// Address of server data channel (DC)
+	serverDCAddr := serverCCAddr.Copy()
+	serverDCAddr.Host.Port = serverCCAddr.Host.Port + 1
+	// DC ports are passed in the request
+	clientBwp.Port = uint16(clientDCAddr.Port)
+	serverBwp.Port = uint16(serverDCAddr.Host.Port)
+
+	// Data channel connection
+	dcConn, err := appnet.DefNetwork().Dial(
+		context.TODO(), "udp", clientDCAddr, serverDCAddr, addr.SvcNone)
+	if err != nil {
+		return
 	}
 
-	receiveDone.Lock()
-	go HandleDCConnReceive(&serverBwp, DCConn, &res, &resLock, &receiveDone)
+	// Start receiver before even sending the request so it will be ready.
+	receiveRes := make(chan BwtestResult, 1)
+	go func() {
+		receiveRes <- HandleDCConnReceive(serverBwp, dcConn)
+	}()
 
-	pktbuf := make([]byte, 2000)
-	pktbuf[0] = 'N' // Request for new bwtest
-	n := EncodeBwtestParameters(&clientBwp, pktbuf[1:])
-	l := n + 1
-	n = EncodeBwtestParameters(&serverBwp, pktbuf[l:])
-	l = l + n
+	// Send the request; when this finishes, the server may have already started blasting.
+	err = requestNewBwtest(ccConn, clientBwp, serverBwp)
+	if err != nil {
+		return
+	}
+	startTime := time.Now()
+	finishTimeReceive := startTime.Add(serverBwp.BwtestDuration + StragglerWaitPeriod)
+	finishTimeSend := startTime.Add(clientBwp.BwtestDuration + GracePeriodSend)
+	if err = dcConn.SetReadDeadline(finishTimeReceive); err != nil {
+		dcConn.Close()
+		return
+	}
+	if err = dcConn.SetWriteDeadline(finishTimeSend); err != nil {
+		dcConn.Close()
+		return
+	}
 
-	var numtries int64 = 0
-	for numtries < MaxTries {
-		_, err = CCConn.Write(pktbuf[:l])
-		Check(err)
+	// Start blasting client->server
+	err = HandleDCConnSend(clientBwp, dcConn)
+	if err != nil && !errors.Is(err, os.ErrDeadlineExceeded) {
+		dcConn.Close()
+		return
+	}
 
-		err = CCConn.SetReadDeadline(time.Now().Add(MaxRTT))
-		Check(err)
-		n, err = CCConn.Read(pktbuf)
+	// Wait until receive is done as well
+	clientRes = <-receiveRes
+	dcConn.Close()
+
+	serverRes, err = requestResults(ccConn, clientBwp.PrgKey)
+	return
+}
+
+// requestNewBwtest makes a new bandwidth test request at the server.
+// Returns nil once the server has accepted the request and an error otherwise.
+func requestNewBwtest(ccConn net.Conn, clientBwp, serverBwp BwtestParameters) error {
+	request := make([]byte, 2000)
+	request[0] = 'N' // Request for new bwtest
+	nc, err := EncodeBwtestParameters(clientBwp, request[1:])
+	if err != nil {
+		return fmt.Errorf("encoding client->server parameters: %w", err)
+	}
+	ns, err := EncodeBwtestParameters(serverBwp, request[1+nc:])
+	if err != nil {
+		return fmt.Errorf("encoding server->client parameters: %w", err)
+	}
+	request = request[:1+nc+ns]
+
+	response := make([]byte, 3)
+	for numtries := 0; numtries < MaxTries; {
+		_, err := ccConn.Write(request)
 		if err != nil {
-			// A timeout likely happened, see if we should adjust the expected finishing time
-			expFinishTimeReceive = time.Now().Add(clientBwp.BwtestDuration + MaxRTT + StragglerWaitPeriod)
-			resLock.Lock()
-			if res.ExpectedFinishTime.Before(expFinishTimeReceive) {
-				res.ExpectedFinishTime = expFinishTimeReceive
-			}
-			resLock.Unlock()
+			return err
+		}
 
+		err = ccConn.SetReadDeadline(time.Now().Add(MaxRTT))
+		if err != nil {
+			return err
+		}
+		n, err := ccConn.Read(response)
+		if errors.Is(err, os.ErrDeadlineExceeded) {
 			numtries++
 			continue
+		} else if err != nil {
+			return err
 		}
-		// Remove read deadline
-		err = CCConn.SetReadDeadline(tzero)
-		Check(err)
 
-		if n != 2 {
+		if n != 2 || response[0] != 'N' {
 			fmt.Println("Incorrect server response, trying again")
 			time.Sleep(Timeout)
 			numtries++
 			continue
 		}
-		if pktbuf[0] != 'N' {
-			fmt.Println("Incorrect server response, trying again")
-			time.Sleep(Timeout)
-			numtries++
-			continue
-		}
-		if pktbuf[1] != 0 {
+		if response[1] != 0 {
 			// The server asks us to wait for some amount of time
-			time.Sleep(time.Second * time.Duration(int(pktbuf[1])))
+			time.Sleep(time.Second * time.Duration(int(response[1])))
 			// Don't increase numtries in this case
 			continue
 		}
 
 		// Everything was successful, exit the loop
-		break
+		return nil
 	}
 
-	if numtries == MaxTries {
-		Check(fmt.Errorf("Error, could not receive a server response, MaxTries attempted without success."))
-	}
+	return fmt.Errorf("could not receive a server response, MaxTries attempted without success.")
+}
 
-	go HandleDCConnSend(&clientBwp, DCConn)
-
-	receiveDone.Lock()
-
-	fmt.Println("\nS->C results")
-	att := 8 * serverBwp.PacketSize * serverBwp.NumPackets / int64(serverBwp.BwtestDuration/time.Second)
-	ach := 8 * serverBwp.PacketSize * res.CorrectlyReceived / int64(serverBwp.BwtestDuration/time.Second)
-	fmt.Printf("Attempted bandwidth: %d bps / %.2f Mbps\n", att, float64(att)/1000000)
-	fmt.Printf("Achieved bandwidth: %d bps / %.2f Mbps\n", ach, float64(ach)/1000000)
-	fmt.Println("Loss rate:", (serverBwp.NumPackets-res.CorrectlyReceived)*100/serverBwp.NumPackets, "%")
-	variance := res.IPAvar
-	average := res.IPAavg
-	fmt.Printf("Interarrival time variance: %dms, average interarrival time: %dms\n",
-		variance/1e6, average/1e6)
-	fmt.Printf("Interarrival time min: %dms, interarrival time max: %dms\n",
-		res.IPAmin/1e6, res.IPAmax/1e6)
-
+func requestResults(ccConn net.Conn, prgKey []byte) (BwtestResult, error) {
 	// Fetch results from server
-	numtries = 0
-	for numtries < MaxTries {
-		pktbuf[0] = 'R'
-		copy(pktbuf[1:], clientBwp.PrgKey)
-		_, err = CCConn.Write(pktbuf[:1+len(clientBwp.PrgKey)])
-		Check(err)
+	req := make([]byte, 1+len(prgKey))
+	req[0] = 'R'
+	copy(req[1:], prgKey)
 
-		err = CCConn.SetReadDeadline(time.Now().Add(MaxRTT))
-		Check(err)
-		n, err = CCConn.Read(pktbuf)
+	response := make([]byte, 2000)
+
+	for numtries := 0; numtries < MaxTries; {
+		_, err := ccConn.Write(req)
 		if err != nil {
+			return BwtestResult{}, err
+		}
+
+		err = ccConn.SetReadDeadline(time.Now().Add(MaxRTT))
+		if err != nil {
+			return BwtestResult{}, err
+		}
+		n, err := ccConn.Read(response)
+		if errors.Is(err, os.ErrDeadlineExceeded) {
 			numtries++
 			continue
+		} else if err != nil {
+			return BwtestResult{}, err
 		}
-		// Remove read deadline
-		err = CCConn.SetReadDeadline(tzero)
-		Check(err)
 
 		if n < 2 {
 			numtries++
 			continue
 		}
-		if pktbuf[0] != 'R' {
+		if response[0] != 'R' {
 			numtries++
 			continue
 		}
-		if pktbuf[1] != byte(0) {
-			// Error case
-			if pktbuf[1] == byte(127) {
-				Check(fmt.Errorf("Results could not be found or PRG key was incorrect, abort"))
-			}
+		if response[1] == byte(127) {
+			return BwtestResult{}, fmt.Errorf("Results could not be found or PRG key was incorrect")
+		} else if response[1] != byte(0) {
 			// pktbuf[1] contains number of seconds to wait for results
-			fmt.Println("We need to sleep for", pktbuf[1], "seconds before we can get the results")
-			time.Sleep(time.Duration(pktbuf[1]) * time.Second)
+			fmt.Println("We need to sleep for", response[1], "seconds before we can get the results")
+			time.Sleep(time.Duration(response[1]) * time.Second)
 			// We don't increment numtries as this was not a lost packet or other communication error
 			continue
 		}
 
-		sres, n1, err := DecodeBwtestResult(pktbuf[2:])
+		res, n1, err := DecodeBwtestResult(response[2:])
 		if err != nil {
 			fmt.Println("Decoding error, try again")
 			numtries++
 			continue
 		}
 		if n1+2 < n {
-			fmt.Println("Insufficient number of bytes received, try again")
+			fmt.Println("Trailing bytes in response, try again")
 			time.Sleep(Timeout)
 			numtries++
 			continue
 		}
-		if !bytes.Equal(clientBwp.PrgKey, sres.PrgKey) {
+		if !bytes.Equal(prgKey, res.PrgKey) {
 			fmt.Println("PRG Key returned from server incorrect, this should never happen")
 			numtries++
 			continue
 		}
-		fmt.Println("\nC->S results")
-		att = 8 * clientBwp.PacketSize * clientBwp.NumPackets / int64(clientBwp.BwtestDuration/time.Second)
-		ach = 8 * clientBwp.PacketSize * sres.CorrectlyReceived / int64(clientBwp.BwtestDuration/time.Second)
-		fmt.Printf("Attempted bandwidth: %d bps / %.2f Mbps\n", att, float64(att)/1000000)
-		fmt.Printf("Achieved bandwidth: %d bps / %.2f Mbps\n", ach, float64(ach)/1000000)
-		fmt.Println("Loss rate:", (clientBwp.NumPackets-sres.CorrectlyReceived)*100/clientBwp.NumPackets, "%")
-		variance := sres.IPAvar
-		average := sres.IPAavg
-		fmt.Printf("Interarrival time variance: %dms, average interarrival time: %dms\n",
-			variance/1e6, average/1e6)
-		fmt.Printf("Interarrival time min: %dms, interarrival time max: %dms\n",
-			sres.IPAmin/1e6, sres.IPAmax/1e6)
-		return
+		return res, nil
 	}
+	return BwtestResult{}, fmt.Errorf("could not fetch server results, MaxTries attempted without success")
+}
 
-	fmt.Println("Error, could not fetch server results, MaxTries attempted without success.")
+func printBwtestResult(bwp BwtestParameters, res BwtestResult) {
+	att := 8 * bwp.PacketSize * bwp.NumPackets / int64(bwp.BwtestDuration/time.Second)
+	ach := 8 * bwp.PacketSize * res.CorrectlyReceived / int64(bwp.BwtestDuration/time.Second)
+	fmt.Printf("Attempted bandwidth: %d bps / %.2f Mbps\n", att, float64(att)/1000000)
+	fmt.Printf("Achieved bandwidth: %d bps / %.2f Mbps\n", ach, float64(ach)/1000000)
+	fmt.Println("Loss rate:", (bwp.NumPackets-res.CorrectlyReceived)*100/bwp.NumPackets, "%")
+	fmt.Printf("Interarrival time min/avg/max/mdev = %.3f/%.3f/%.3f/%.3f ms\n",
+		float64(res.IPAmin)/1e6,
+		float64(res.IPAavg)/1e6,
+		float64(res.IPAmax)/1e6,
+		math.Sqrt(float64(res.IPAvar)/1e6),
+	)
 }

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -523,7 +523,11 @@ func printBwtestResult(bwp BwtestParameters, res BwtestResult) {
 	ach := 8 * bwp.PacketSize * res.CorrectlyReceived / int64(bwp.BwtestDuration/time.Second)
 	fmt.Printf("Attempted bandwidth: %d bps / %.2f Mbps\n", att, float64(att)/1000000)
 	fmt.Printf("Achieved bandwidth: %d bps / %.2f Mbps\n", ach, float64(ach)/1000000)
-	fmt.Println("Loss rate:", (bwp.NumPackets-res.CorrectlyReceived)*100/bwp.NumPackets, "%")
+	loss := 0.0
+	if bwp.NumPackets > 0 {
+		loss = float64(bwp.NumPackets-res.CorrectlyReceived) * 100.0 / float64(bwp.NumPackets)
+	}
+	fmt.Printf("Loss rate: %.1f%%\n", loss)
 	fmt.Printf("Interarrival time min/avg/max/mdev = %.3f/%.3f/%.3f/%.3f ms\n",
 		float64(res.IPAmin)/1e6,
 		float64(res.IPAavg)/1e6,

--- a/bwtester/bwtestlib/bwtestlib.go
+++ b/bwtester/bwtestlib/bwtestlib.go
@@ -17,16 +17,14 @@ package bwtestlib
 import (
 	"bytes"
 	"crypto/aes"
+	"crypto/cipher"
 	"encoding/binary"
 	"encoding/gob"
+	"fmt"
+	"io"
 	"os"
 	"sort"
-	"sync"
 	"time"
-
-	log "github.com/inconshreveable/log15"
-
-	"github.com/scionproto/scion/go/lib/snet"
 )
 
 const (
@@ -44,7 +42,7 @@ const (
 	// Make sure the port number is a port the server application can connect to
 	MinPort uint16 = 1024
 
-	MaxTries int64         = 5 // Number of times to try to reach server
+	MaxTries               = 5 // Number of times to try to reach server
 	Timeout  time.Duration = time.Millisecond * 500
 	MaxRTT   time.Duration = time.Millisecond * 1000
 )
@@ -66,153 +64,122 @@ type BwtestResult struct {
 	IPAmax             int64
 	// Contains the client's sending PRG key, so that the result can be uniquely identified
 	// Only requests that contain the correct key can obtain the result
-	PrgKey             []byte
-	ExpectedFinishTime time.Time
+	PrgKey []byte
 }
 
 func Check(e error) {
 	if e != nil {
-		LogFatal("Fatal error. Exiting.", "err", e)
+		fmt.Fprintln(os.Stderr, "Fatal:", e)
+		os.Exit(1)
 	}
 }
 
-func LogFatal(msg string, a ...interface{}) {
-	log.Crit(msg, a...)
-	os.Exit(1)
+type prgFiller struct {
+	aes cipher.Block
+	buf []byte
 }
 
-// Fill buffer with AES PRG in counter mode
-// The value of the ith 16-byte block is simply an encryption of i under the key
-func PrgFill(key []byte, iv int, data []byte) {
-	i := uint32(iv)
+func newPrgFiller(key []byte) *prgFiller {
 	aesCipher, err := aes.NewCipher(key)
 	Check(err)
-	pt := make([]byte, aes.BlockSize)
+	return &prgFiller{
+		aes: aesCipher,
+		buf: make([]byte, aes.BlockSize),
+	}
+}
+
+// Fill the buffer with AES PRG in counter mode
+// The value of the ith 16-byte block is simply an encryption of i under the key
+func (f *prgFiller) Fill(iv int, data []byte) {
+	i := uint32(iv)
 	j := 0
 	for j <= len(data)-aes.BlockSize {
-		binary.LittleEndian.PutUint32(pt, i)
-		aesCipher.Encrypt(data, pt)
+		binary.LittleEndian.PutUint32(f.buf, i)
+		f.aes.Encrypt(data, f.buf)
 		j = j + aes.BlockSize
 		i = i + uint32(aes.BlockSize)
 	}
 	// Check if fewer than BlockSize bytes are required for the final block
 	if j < len(data) {
-		binary.LittleEndian.PutUint32(pt, i)
-		aesCipher.Encrypt(pt, pt)
-		copy(data[j:], pt[:len(data)-j])
+		binary.LittleEndian.PutUint32(f.buf, i)
+		f.aes.Encrypt(f.buf, f.buf)
+		copy(data[j:], f.buf[:len(data)-j])
 	}
 }
 
 // Encode BwtestResult into a sufficiently large byte buffer that is passed in, return the number of bytes written
-func EncodeBwtestResult(res *BwtestResult, buf []byte) int {
+func EncodeBwtestResult(res BwtestResult, buf []byte) (int, error) {
 	var bb bytes.Buffer
 	enc := gob.NewEncoder(&bb)
-	err := enc.Encode(*res)
-	Check(err)
+	err := enc.Encode(res)
 	copy(buf, bb.Bytes())
-	return bb.Len()
+	return bb.Len(), err
 }
 
 // Decode BwtestResult from byte buffer that is passed in, returns BwtestResult structure and number of bytes consumed
-func DecodeBwtestResult(buf []byte) (*BwtestResult, int, error) {
+func DecodeBwtestResult(buf []byte) (BwtestResult, int, error) {
 	bb := bytes.NewBuffer(buf)
 	is := bb.Len()
 	dec := gob.NewDecoder(bb)
 	var v BwtestResult
 	err := dec.Decode(&v)
-	return &v, is - bb.Len(), err
+	return v, is - bb.Len(), err
 }
 
 // Encode BwtestParameters into a sufficiently large byte buffer that is passed in, return the number of bytes written
-func EncodeBwtestParameters(bwtp *BwtestParameters, buf []byte) int {
+func EncodeBwtestParameters(bwtp BwtestParameters, buf []byte) (int, error) {
 	var bb bytes.Buffer
 	enc := gob.NewEncoder(&bb)
-	err := enc.Encode(*bwtp)
-	Check(err)
+	err := enc.Encode(bwtp)
 	copy(buf, bb.Bytes())
-	return bb.Len()
+	return bb.Len(), err
 }
 
 // Decode BwtestParameters from byte buffer that is passed in, returns BwtestParameters structure and number of bytes consumed
-func DecodeBwtestParameters(buf []byte) (*BwtestParameters, int, error) {
+func DecodeBwtestParameters(buf []byte) (BwtestParameters, int, error) {
 	bb := bytes.NewBuffer(buf)
 	is := bb.Len()
 	dec := gob.NewDecoder(bb)
 	var v BwtestParameters
 	err := dec.Decode(&v)
-	// Make sure that arguments are within correct parameter ranges
-	if v.BwtestDuration > MaxDuration {
-		v.BwtestDuration = MaxDuration
-	}
-	if v.BwtestDuration < time.Duration(0) {
-		v.BwtestDuration = time.Duration(0)
-	}
-	if v.PacketSize < MinPacketSize {
-		v.PacketSize = MinPacketSize
-	}
-	if v.PacketSize > MaxPacketSize {
-		v.PacketSize = MaxPacketSize
-	}
-	if v.Port < MinPort {
-		v.Port = MinPort
-	}
-	return &v, is - bb.Len(), err
+	return v, is - bb.Len(), err
 }
 
-func HandleDCConnSend(bwp *BwtestParameters, udpConnection *snet.Conn) {
+func HandleDCConnSend(bwp BwtestParameters, udpConnection io.Writer) error {
 	sb := make([]byte, bwp.PacketSize)
-	var i int64 = 0
 	t0 := time.Now()
-	finish := t0.Add(bwp.BwtestDuration + GracePeriodSend)
-	var interPktInterval time.Duration
+	interPktInterval := bwp.BwtestDuration
 	if bwp.NumPackets > 1 {
 		interPktInterval = bwp.BwtestDuration / time.Duration(bwp.NumPackets-1)
-	} else {
-		interPktInterval = bwp.BwtestDuration
 	}
-	for i < bwp.NumPackets {
-		// Compute how long to wait
-		t1 := time.Now()
-		if t1.After(finish) {
-			// We've been sending for too long, sending bandwidth must be insufficient. Abort sending.
-			return
-		}
-		t2 := t0.Add(interPktInterval * time.Duration(i))
-		if t1.Before(t2) {
-			time.Sleep(t2.Sub(t1))
-		}
+	prgFiller := newPrgFiller(bwp.PrgKey)
+	for i := int64(0); i < bwp.NumPackets; i++ {
+		time.Sleep(time.Until(t0.Add(interPktInterval * time.Duration(i))))
 		// Send packet now
-		PrgFill(bwp.PrgKey, int(i*bwp.PacketSize), sb)
+		prgFiller.Fill(int(i*bwp.PacketSize), sb)
 		// Place packet number at the beginning of the packet, overwriting some PRG data
 		binary.LittleEndian.PutUint32(sb, uint32(i*bwp.PacketSize))
 		_, err := udpConnection.Write(sb)
-		Check(err)
-		i++
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func HandleDCConnReceive(bwp *BwtestParameters, udpConnection *snet.Conn, res *BwtestResult, resLock *sync.Mutex, done *sync.Mutex) {
-	resLock.Lock()
-	finish := res.ExpectedFinishTime
-	resLock.Unlock()
-	var numPacketsReceived, correctlyReceived int64 = 0, 0
-	InterPacketArrivalTime := make(map[int]int64)
-	_ = udpConnection.SetReadDeadline(finish)
+func HandleDCConnReceive(bwp BwtestParameters, udpConnection io.Reader) BwtestResult {
+	var numPacketsReceived int64
+	var correctlyReceived int64
+	interPacketArrivalTime := make(map[int]int64, bwp.NumPackets)
+
 	// Make the receive buffer a bit larger to enable detection of packets that are too large
-	recBuf := make([]byte, bwp.PacketSize+1000)
+	recBuf := make([]byte, bwp.PacketSize+1)
 	cmpBuf := make([]byte, bwp.PacketSize)
-	for time.Now().Before(finish) && correctlyReceived < bwp.NumPackets {
+	prgFiller := newPrgFiller(bwp.PrgKey)
+	for correctlyReceived < bwp.NumPackets {
 		n, err := udpConnection.Read(recBuf)
-		// Ignore errors, todo: detect type of error and quit if it was because of a SetReadDeadline
-		if err != nil {
-			// If the ReadDeadline expired, then we should extend the finish time, which is
-			// extended on the client side if no response is received from the server. On the server
-			// side, however, a short BwtestDuration with several consecutive packet losses would
-			// lead to closing the connection.
-			resLock.Lock()
-			finish = res.ExpectedFinishTime
-			resLock.Unlock()
-			continue
+		if err != nil { // Deadline exceeded or read error
+			break
 		}
 		numPacketsReceived++
 		if int64(n) != bwp.PacketSize {
@@ -228,52 +195,21 @@ func HandleDCConnReceive(bwp *BwtestParameters, udpConnection *snet.Conn, res *B
 		// entire packet
 		iv := int64(binary.LittleEndian.Uint32(recBuf))
 		seqNo := int(iv / bwp.PacketSize)
-		InterPacketArrivalTime[seqNo] = time.Now().UnixNano()
-		PrgFill(bwp.PrgKey, int(iv), cmpBuf)
+		interPacketArrivalTime[seqNo] = time.Now().UnixNano()
+		prgFiller.Fill(int(iv), cmpBuf)
 		binary.LittleEndian.PutUint32(cmpBuf, uint32(iv))
 		if bytes.Equal(recBuf[:bwp.PacketSize], cmpBuf) {
-			if correctlyReceived == 0 {
-				// Adjust finish time after first correctly received packet
-				// Note that we should check that we're not too far away from the beginning of the
-				// bwtest, otherwise we're extending the time for too long. If the server's 'N' response
-				// packet was not dropped, then sending should start within MaxRTT at most.
-				newFinish := time.Now().Add(bwp.BwtestDuration + StragglerWaitPeriod)
-				if newFinish.After(finish) {
-					finish = newFinish
-					_ = udpConnection.SetReadDeadline(finish)
-					resLock.Lock()
-					if res.ExpectedFinishTime.Before(finish) {
-						// Most likely what happened is that the server's 'N' response packet got dropped (in case this
-						// is the receive function on the server side) or the client's request packet got dropped (in
-						// case this is the receive function on the client side). In both cases the ExpectedFinishTime
-						// needs to be updated
-						res.ExpectedFinishTime = finish
-					}
-					resLock.Unlock()
-				}
-			}
 			correctlyReceived++
 		}
 	}
 
-	resLock.Lock()
-	res.NumPacketsReceived = numPacketsReceived
-	res.CorrectlyReceived = correctlyReceived
-	res.IPAvar, res.IPAmin, res.IPAavg, res.IPAmax = aggrInterArrivalTime(InterPacketArrivalTime)
-
-	// We're done here, let's see if we need to wait for the send function to complete so we can close the connection
-	// Note: the locking here is not strictly necessary, since ExpectedFinishTime is only updated right after
-	// initialization and in the code above, but it's good practice to do always lock when using the variable
-	eft := res.ExpectedFinishTime
-	resLock.Unlock()
-	if done != nil {
-		// Signal that we're done
-		done.Unlock()
+	res := BwtestResult{
+		NumPacketsReceived: numPacketsReceived,
+		CorrectlyReceived:  correctlyReceived,
+		PrgKey:             bwp.PrgKey,
 	}
-	if time.Now().Before(eft) {
-		time.Sleep(time.Until(eft))
-	}
-	_ = udpConnection.Close()
+	res.IPAvar, res.IPAmin, res.IPAavg, res.IPAmax = aggrInterArrivalTime(interPacketArrivalTime)
+	return res
 }
 
 func aggrInterArrivalTime(bwr map[int]int64) (IPAvar, IPAmin, IPAavg, IPAmax int64) {

--- a/bwtester/bwtestlib/bwtestlib.go
+++ b/bwtester/bwtestlib/bwtestlib.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// Maximum duration of a bandwidth test
-	MaxDuration time.Duration = time.Second * 10
+	MaxDuration time.Duration = time.Minute * 5
 	// Maximum amount of time to wait for straggler packets
 	StragglerWaitPeriod time.Duration = time.Second
 	// Allow sending beyond the finish time by this amount


### PR DESCRIPTION
Simplification, refactoring, cleanup of the bwtester codebase.

This does not introduce any (significant) behaviour changes; the
applications are compatible with the version before this change.
One breaking change is that we've removed the rather pointless `-id` and
`-log_dir` flags from the bwtestserver.
In the client, the output format has been slightly adapted.

The motivation for this is to make it easier to convert bwtester to use
the pan library. In particular, one goal was to make `HandleDCCnnSend/Receive`
functions (shared between client and server) dumber, i.e making them do
nothing but Write/Read on the connection. This will help to adapt this to
pan with its asymmetric dialed/listening connections.

The most relevant changes are:
* split functions, reduce duplicate code
* try to get some semblance of reasonable error handling
* simplify the termination of tests by simplifying; set Read/Write
  deadlines for the data channel (once!), ensuring that the reader/write
  routines abort in time.
* remove `ExpectedFinishTime` from `BwtestResults` struct. Was only used
  for (unnecessarily confusing) internal bookkeeping, does not need to
  be on the wire. The "gob" encoding on the wire is still compatible.
* server: avoid excessive concurrent access to results map to get rid of
  the excessive locking code. Only add the result entry once it's
  actually available (it's so much easier...).
* client: shorten output format for Interarrival time (~analogous to
  ping output)

Note that this is a limited cleanup pass, trying not to change too much
at once and not to introduce breaking changes. The code (and the
functionality) can clearly still be improved...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/209)
<!-- Reviewable:end -->
