### PR TITLE
lint: enable more linters fix many issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,31 +14,47 @@ linters:
     #- typecheck
     #- unused
     #- varcheck
-    - gofmt
-    - stylecheck # replacement for golint
+    - asciicheck
+    - bidichk
+    - contextcheck
     - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exportloopref
+    - gci
+    - gofmt
+    - ifshort
+    - importas
+    - makezero
     - misspell
-
+    - nilerr
+    - nilnil
+    - nolintlint
+    - prealloc
+    - stylecheck
+    - thelper
+    - wastedassign
+    - tenv
 
 issues:
   # XXX exclude some linters where there are too many issues to fix now
   exclude-rules:
-    - path: bwtester/
-      linters:
-        - stylecheck
     - path: webapp/
       linters:
         - stylecheck
         - staticcheck
         - errcheck
-    - path: ssh/
-      linters:
-        - errcheck
-        
-
   max-same-issues: 0
 
+linters-settings:
+  gci:
+    local-prefixes: github.com/netsec-ethz/scion-apps
+  exhaustive:
+    default-signifies-exhaustive: true
+
 run:
+  build-tags: integration
   # Bat is mostly copied third-party code that we don't care to fix
   # Modifications are only (?) in bat/bat.go
   skip-dirs:

--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -41,7 +41,7 @@ func main() {
 	flag.Parse()
 
 	if (listen.Get().Port() > 0) == (len(*remoteAddr) > 0) {
-		check(fmt.Errorf("Either specify -port for server or -remote for client"))
+		check(fmt.Errorf("either specify -port for server or -remote for client"))
 	}
 
 	if listen.Get().Port() > 0 {
@@ -93,6 +93,9 @@ func workSession(session quic.Session) error {
 		}
 		fmt.Printf("%s\n", data)
 		_, err = stream.Write([]byte("gotcha: "))
+		if err != nil {
+			return err
+		}
 		_, err = stream.Write(data)
 		if err != nil {
 			return err
@@ -131,10 +134,12 @@ func runClient(address string, count int) error {
 		}
 		stream.Close()
 		reply, err := ioutil.ReadAll(stream)
+		if err != nil {
+			return err
+		}
 		fmt.Printf("%s\n", reply)
 	}
-	session.CloseWithError(quic.ApplicationErrorCode(0), "")
-	return nil
+	return session.CloseWithError(quic.ApplicationErrorCode(0), "")
 }
 
 // Check just ensures the error is nil, or complains and quits

--- a/_examples/helloworld/helloworld.go
+++ b/_examples/helloworld/helloworld.go
@@ -37,7 +37,7 @@ func main() {
 	flag.Parse()
 
 	if (listen.Get().Port() > 0) == (len(*remoteAddr) > 0) {
-		check(fmt.Errorf("Either specify -listen for server or -remote for client"))
+		check(fmt.Errorf("either specify -listen for server or -remote for client"))
 	}
 
 	if listen.Get().Port() > 0 {
@@ -67,6 +67,9 @@ func runServer(listen netaddr.IPPort) error {
 		fmt.Printf("Received %s: %s\n", from, data)
 		msg := fmt.Sprintf("take it back! %s", time.Now().Format("15:04:05.0"))
 		n, err = conn.WriteTo([]byte(msg), from)
+		if err != nil {
+			return err
+		}
 		fmt.Printf("Wrote %d bytes.\n", n)
 	}
 }
@@ -90,7 +93,9 @@ func runClient(address string, count int) error {
 		fmt.Printf("Wrote %d bytes.\n", nBytes)
 
 		buffer := make([]byte, 16*1024)
-		conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		if err = conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+			return err
+		}
 		n, err := conn.Read(buffer)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			continue

--- a/_examples/helloworld/helloworld_integration_test.go
+++ b/_examples/helloworld/helloworld_integration_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/_examples/shttp/fileserver/main.go
+++ b/_examples/shttp/fileserver/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
+
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 

--- a/_examples/shttp/proxy/main.go
+++ b/_examples/shttp/proxy/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
+
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 

--- a/_examples/shttp/server/main.go
+++ b/_examples/shttp/server/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
+
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 
@@ -38,7 +39,7 @@ func main() {
 	m.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		// Status 200 OK will be set implicitly
 		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte(`Oh, hello!`))
+		_, _ = w.Write([]byte(`Oh, hello!`))
 	})
 
 	// handler that responds with an image file
@@ -75,7 +76,10 @@ func main() {
 	// POST handler that responds by parsing form values and returns them as string
 	m.HandleFunc("/form", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "invalid form data", http.StatusBadRequest)
+				return
+			}
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprint(w, "received following data:\n")
 			for s := range r.PostForm {

--- a/bwtester/bwtestclient/bwtestclient_integration_test.go
+++ b/bwtester/bwtestclient/bwtestclient_integration_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/netsec-ethz/scion-apps
 go 1.16
 
 require (
-	github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84
 	github.com/creack/pty v1.1.17
 	github.com/gorilla/handlers v1.5.1
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/bazelbuild/rules_go v0.27.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
-github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84 h1:cutFptzj+ospnc1PETUqcSVTH3VQ44Bi0rpt3nE9gvo=
-github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84/go.mod h1:Va9ap1qxjAWkIVaW1E9rH0aNgE8SDI5A4n8Ds8P0fAA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/netcat/netcat_integration_test.go
+++ b/netcat/netcat_integration_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 // TestIntegrationScionNetcatCmd runs the netcat listeners in -c mode, returning a
 // fixed string for each newly connected client.
 // This mode is easiest to test here as it does not require any stdin/out redirections
-// and the clients can terminate succesfully without interrupting them.
+// and the clients can terminate successfully without interrupting them.
 // XXX: This is testing the "happy" path only, meaning pretty much anything
 // else does not currently work.
 func TestIntegrationScionNetcatCmd(t *testing.T) {

--- a/pkg/integration/apps.go
+++ b/pkg/integration/apps.go
@@ -195,7 +195,7 @@ func (sai *ScionAppsIntegration) Run(t *testing.T, pairs []sintegration.IAPair) 
 
 	// First run all servers
 	dsts := sintegration.ExtractUniqueDsts(pairs)
-	var serverClosers []io.Closer
+	serverClosers := make([]io.Closer, 0, len(dsts))
 	for _, dst := range dsts {
 		c, err := sintegration.StartServer(sai, dst)
 		if err != nil {

--- a/pkg/pan/cli.go
+++ b/pkg/pan/cli.go
@@ -67,9 +67,7 @@ func PolicyFromCommandline(sequence string, preference string, interactive bool)
 			Prompter: CommandlinePrompter{},
 		})
 	}
-	if len(chain) == 0 {
-		return nil, nil
-	} else if len(chain) == 1 {
+	if len(chain) == 1 {
 		return chain[0], nil
 	} else {
 		return chain, nil

--- a/pkg/pan/hostsfile.go
+++ b/pkg/pan/hostsfile.go
@@ -36,7 +36,7 @@ func (r *hostsfileResolver) Resolve(name string) (scionAddr, error) {
 	// for now that would be overkill.
 	table, err := loadHostsFile(r.path)
 	if err != nil {
-		return scionAddr{}, fmt.Errorf("error loading %s: %s", r.path, err)
+		return scionAddr{}, fmt.Errorf("error loading %s: %w", r.path, err)
 	}
 	addr, ok := table[name]
 	if !ok {
@@ -50,7 +50,7 @@ func loadHostsFile(path string) (hostsTable, error) {
 	if os.IsNotExist(err) {
 		// not existing file treated like an empty file,
 		// just return an empty table
-		return nil, nil
+		return hostsTable(nil), nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/interactive.go
+++ b/pkg/pan/interactive.go
@@ -85,7 +85,7 @@ func (p CommandlinePrompter) Prompt(paths []*Path, remote IA) []*Path {
 		fmt.Fprintf(os.Stderr, "ERROR: Invalid path selection. %v\n", err)
 	}
 
-	var selectedPaths []*Path
+	selectedPaths := make([]*Path, 0, len(pathIndices))
 	for _, i := range pathIndices {
 		selectedPaths = append(selectedPaths, paths[i])
 	}
@@ -137,7 +137,7 @@ func parsePathChoice(selection string, max int) (pathIndices []int, err error) {
 func parsePathIndex(index string, max int) (int, error) {
 	pathIndex, err := strconv.ParseUint(index, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid choice: '%v', %v", index, err)
+		return 0, fmt.Errorf("invalid choice: '%v', %w", index, err)
 	}
 	if pathIndex > uint64(max) {
 		return 0, fmt.Errorf("invalid choice: '%v', valid indices range: [0, %v]", index, max)

--- a/pkg/pan/path.go
+++ b/pkg/pan/path.go
@@ -109,7 +109,7 @@ func (p ForwardingPath) forwardingPathInfo() (forwardingPathInfo, error) {
 // The created Path includes fingerprint and expiry information.
 func reversePathFromForwardingPath(src, dst IA, fwPath ForwardingPath) (*Path, error) {
 	if fwPath.IsEmpty() {
-		return nil, nil
+		return (*Path)(nil), nil
 	}
 	// FIXME: inefficient, decoding twice! Change this to decode and then both
 	// reverse and extract fw info

--- a/pkg/pan/rains.go
+++ b/pkg/pan/rains.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !norains
 // +build !norains
 
 package pan
@@ -51,11 +52,11 @@ func readRainsConfig() (UDPAddr, error) {
 	if os.IsNotExist(err) {
 		return UDPAddr{}, nil
 	} else if err != nil {
-		return UDPAddr{}, fmt.Errorf("error loading %s: %s", rainsConfigPath, err)
+		return UDPAddr{}, fmt.Errorf("error loading %s: %w", rainsConfigPath, err)
 	}
 	address, err := ParseUDPAddr(strings.TrimSpace(string(bs)))
 	if err != nil {
-		return UDPAddr{}, fmt.Errorf("error parsing %s, expected SCION UDP address: %s", rainsConfigPath, err)
+		return UDPAddr{}, fmt.Errorf("error parsing %s, expected SCION UDP address: %w", rainsConfigPath, err)
 	}
 	return address, nil
 }
@@ -77,7 +78,7 @@ func rainsQuery(server UDPAddr, hostname string) (scionAddr, error) {
 	srv := server.snetUDPAddr()
 	reply, err := rains.Query(hostname, ctx, []rains.Type{qType}, qOpts, expire, timeout, srv)
 	if err != nil {
-		return scionAddr{}, fmt.Errorf("address for host %q not found: %v", hostname, err)
+		return scionAddr{}, fmt.Errorf("address for host %q not found: %w", hostname, err)
 	}
 	addrStr, ok := reply[qType]
 	if !ok {
@@ -85,7 +86,7 @@ func rainsQuery(server UDPAddr, hostname string) (scionAddr, error) {
 	}
 	addr, err := parseSCIONAddr(addrStr)
 	if err != nil {
-		return scionAddr{}, fmt.Errorf("address for host %q invalid: %v", hostname, err)
+		return scionAddr{}, fmt.Errorf("address for host %q invalid: %w", hostname, err)
 	}
 	return addr, nil
 }

--- a/pkg/pan/raw.go
+++ b/pkg/pan/raw.go
@@ -188,7 +188,7 @@ func (h scmpHandler) Handle(pkt *snet.Packet) error {
 		}
 		pf, err := reversePathFingerprint(pkt.Path)
 		if err != nil { // bad packet, drop silently
-			return nil
+			return nil // nolint:nilerr
 		}
 		// FIXME: can block _all_ connections, call async (or internally async)
 		stats.NotifyPathDown(pf, pi)
@@ -201,7 +201,7 @@ func (h scmpHandler) Handle(pkt *snet.Packet) error {
 		}
 		pf, err := reversePathFingerprint(pkt.Path)
 		if err != nil {
-			return nil
+			return nil // nolint:nilerr
 		}
 		stats.NotifyPathDown(pf, pi)
 		return nil
@@ -231,12 +231,16 @@ func (e SCMPError) Error() string {
 func (e SCMPError) Temporary() bool {
 	switch e.typeCode.Type() {
 	case slayers.SCMPTypeDestinationUnreachable:
+		return false
 	case slayers.SCMPTypePacketTooBig:
+		return false
 	case slayers.SCMPTypeParameterProblem:
 		return false
 	case slayers.SCMPTypeExternalInterfaceDown:
+		return true
 	case slayers.SCMPTypeInternalConnectivityDown:
 		return true
+	default:
+		panic("invalid error code")
 	}
-	panic("invalid error code")
 }

--- a/pkg/pan/sciond.go
+++ b/pkg/pan/sciond.go
@@ -114,8 +114,8 @@ func findDispatcherSocket() (string, error) {
 	if !ok {
 		path = reliable.DefaultDispPath
 	}
-	err := statSocket(path)
-	if err != nil {
+
+	if err := statSocket(path); err != nil {
 		return "", fmt.Errorf("error looking for SCION dispatcher socket at %s (override with SCION_DISPATCHER_SOCKET): %w", path, err)
 	}
 	return path, nil

--- a/pkg/pan/selector.go
+++ b/pkg/pan/selector.go
@@ -270,7 +270,7 @@ func (s *PingingSelector) handlePingReply(reply ping.Reply,
 		if err != nil {
 			return
 		}
-		switch e := reply.Error.(type) {
+		switch e := reply.Error.(type) { // nolint:errorlint
 		case ping.InternalConnectivityDownError:
 			pi := PathInterface{
 				IA:   IA(e.IA),

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -174,7 +174,7 @@ func openPathRefreshSubscriber(ctx context.Context, local, remote UDPAddr, polic
 	}
 	paths, err := pool.subscribe(ctx, remote.IA, s)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	s.target.Initialize(local, remote, filtered(s.policy, paths))
 	return s, nil

--- a/pkg/quicutil/tls.go
+++ b/pkg/quicutil/tls.go
@@ -44,7 +44,7 @@ func MustGenerateSelfSignedCert() []tls.Certificate {
 func GenerateSelfSignedCert() (*tls.Certificate, error) {
 	priv, err := rsaGenerateKey()
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return createCertificate(priv)
 }
@@ -62,7 +62,7 @@ func createCertificate(priv *rsa.PrivateKey) (*tls.Certificate, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate serial number: %s", err)
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	template := x509.Certificate{
@@ -90,7 +90,7 @@ func createCertificate(priv *rsa.PrivateKey) (*tls.Certificate, error) {
 
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal private key: %v", err)
+		return nil, fmt.Errorf("unable to marshal private key: %w", err)
 	}
 
 	keyPEMBuf := &bytes.Buffer{}

--- a/pkg/shttp/server.go
+++ b/pkg/shttp/server.go
@@ -68,7 +68,7 @@ func (srv *Server) ServeTLS(l net.Listener, certFile, keyFile string) error {
 func (srv *Server) ListenAndServe() error {
 	listener, err := listen(srv.Addr)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer listener.Close()
 	return srv.Server.Serve(listener)
@@ -77,7 +77,7 @@ func (srv *Server) ListenAndServe() error {
 func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 	listener, err := listen(srv.Addr)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer listener.Close()
 	return srv.Server.ServeTLS(listener, certFile, keyFile)

--- a/pkg/shttp/transport_test.go
+++ b/pkg/shttp/transport_test.go
@@ -133,7 +133,7 @@ func TestRoundTripper(t *testing.T) {
 			expected = tc.Expected
 
 			url := fmt.Sprintf(urlPattern, tc.HostPort)
-			_, err := c.Get(MangleSCIONAddrURL(url))
+			_, err := c.Get(MangleSCIONAddrURL(url)) // nolint:bodyclose
 			assert.ErrorIs(t, err, errJustATest)
 		}
 	}

--- a/sensorapp/sensorapp_integration_test.go
+++ b/sensorapp/sensorapp_integration_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/skip/main.go
+++ b/skip/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.16
 // +build go1.16
 
 package main

--- a/ssh/client/clientconfig/clientconfig_test.go
+++ b/ssh/client/clientconfig/clientconfig_test.go
@@ -69,7 +69,8 @@ func TestDefaultConfig(t *testing.T) {
 
 		Convey("The new values are read correctly", func() {
 			conf := &ClientConfig{}
-			config.UpdateFromReader(conf, strings.NewReader(configString))
+			err := config.UpdateFromReader(conf, strings.NewReader(configString))
+			So(err, ShouldBeNil)
 			So(conf.HostAddress, ShouldEqual, "")
 			So(conf.PasswordAuthentication, ShouldEqual, "no")
 			So(conf.StrictHostKeyChecking, ShouldEqual, "no")

--- a/ssh/config/config.go
+++ b/ssh/config/config.go
@@ -120,9 +120,8 @@ func UpdateFromReader(conf Config, reader io.Reader) error {
 		}
 	}
 
-	err := scanner.Err()
-	if err != nil {
-		return err
+	if scanner.Err() != nil {
+		return scanner.Err()
 	}
 
 	return nil

--- a/ssh/server/main.go
+++ b/ssh/server/main.go
@@ -106,6 +106,6 @@ func main() {
 		if err != nil {
 			golog.Fatalf("Failed to accept session: %v", err)
 		}
-		go sshServer.HandleConnection(conn)
+		sshServer.HandleConnection(conn)
 	}
 }

--- a/ssh/server/ssh/authcallbacks.go
+++ b/ssh/server/ssh/authcallbacks.go
@@ -34,9 +34,9 @@ func (s *Server) PasswordAuth(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions
 	if err != nil {
 		return nil, err
 	}
-	err = t.Authenticate(0)
-	if err != nil {
-		return nil, fmt.Errorf("authenticate: %s", err.Error())
+
+	if err := t.Authenticate(0); err != nil {
+		return nil, fmt.Errorf("authenticate: %w", err)
 	}
 
 	return &ssh.Permissions{
@@ -71,7 +71,7 @@ func loadAuthorizedKeys(file string) (map[string]bool, error) {
 func (s *Server) PublicKeyAuth(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
 	authKeys, err := loadAuthorizedKeys(s.authorizedKeysFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed loading authorized files: %v", err)
+		return nil, fmt.Errorf("failed loading authorized files: %w", err)
 	}
 
 	if authKeys[string(pubKey.Marshal())] {

--- a/ssh/server/ssh/tunnelchannel.go
+++ b/ssh/server/ssh/tunnelchannel.go
@@ -39,11 +39,11 @@ func handleTunnelForRemoteConnection(connection ssh.Channel, remoteConnection ne
 
 	var once sync.Once
 	go func() {
-		io.Copy(connection, remoteConnection)
+		_, _ = io.Copy(connection, remoteConnection)
 		once.Do(close)
 	}()
 	go func() {
-		io.Copy(remoteConnection, connection)
+		_, _ = io.Copy(remoteConnection, connection)
 		once.Do(close)
 	}()
 }

--- a/webapp/lib/bwcont.go
+++ b/webapp/lib/bwcont.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
+
 	model "github.com/netsec-ethz/scion-apps/webapp/models"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )

--- a/webapp/lib/config.go
+++ b/webapp/lib/config.go
@@ -29,9 +29,10 @@ import (
 	"strings"
 
 	log "github.com/inconshreveable/log15"
-	. "github.com/netsec-ethz/scion-apps/webapp/util"
 	"github.com/pelletier/go-toml"
 	"github.com/scionproto/scion/go/lib/daemon"
+
+	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
 // default params for localhost testing

--- a/webapp/lib/echocont.go
+++ b/webapp/lib/echocont.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
+
 	model "github.com/netsec-ethz/scion-apps/webapp/models"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )

--- a/webapp/lib/health.go
+++ b/webapp/lib/health.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
+
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
@@ -82,13 +83,14 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request, options *CmdOpti
 	}
 
 	// generate local memory struct to export results
-	var results []ResHealthCheck
+	results := make([]ResHealthCheck, 0, len(tests.Tests))
 	for _, test := range tests.Tests {
 		res := ResHealthCheck{Label: test.Label, Title: test.Desc}
 		results = append(results, res)
 	}
 	// export empty result set first
 	jsonRes, err := json.Marshal(results)
+	CheckError(err)
 	err = ioutil.WriteFile(hcResFp, jsonRes, 0644)
 	CheckError(err)
 
@@ -109,6 +111,7 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request, options *CmdOpti
 		// export results when test starts, timestamp
 		results[i].Start = start
 		jsonRes, err = json.Marshal(results)
+		CheckError(err)
 		err = ioutil.WriteFile(hcResFp, jsonRes, 0644)
 		CheckError(err)
 

--- a/webapp/lib/sciond.go
+++ b/webapp/lib/sciond.go
@@ -33,12 +33,13 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
-	pathdb "github.com/netsec-ethz/scion-apps/webapp/models/path"
-	. "github.com/netsec-ethz/scion-apps/webapp/util"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/daemon"
 	"github.com/scionproto/scion/go/lib/snet"
+
+	pathdb "github.com/netsec-ethz/scion-apps/webapp/models/path"
+	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
 // Configuations to save. Zeroing out any of these placeholders will cause the
@@ -243,7 +244,7 @@ func getPathsJSON(sciondConn daemon.Connector, dstIA addr.IA) ([]byte, error) {
 		return nil, err
 	}
 
-	var rPaths []Path
+	rPaths := make([]Path, 0, len(paths))
 	for _, path := range paths {
 		rpath := Path{
 			Fingerprint: snet.Fingerprint(path).String()[:16],

--- a/webapp/lib/traceroutecont.go
+++ b/webapp/lib/traceroutecont.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
+
 	model "github.com/netsec-ethz/scion-apps/webapp/models"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )

--- a/webapp/models/db.go
+++ b/webapp/models/db.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
+
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 

--- a/webapp/models/path/segments.go
+++ b/webapp/models/path/segments.go
@@ -18,12 +18,13 @@ import (
 	"database/sql"
 	"time"
 
-	. "github.com/netsec-ethz/scion-apps/webapp/util"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/proto"
+
+	. "github.com/netsec-ethz/scion-apps/webapp/util"
 )
 
 type asIface struct {

--- a/webapp/models/traceroute.go
+++ b/webapp/models/traceroute.go
@@ -347,7 +347,7 @@ func ReadTracerouteItemsSince(since string) ([]TracerouteGraph, error) {
 	var graphEntries []TracerouteGraph
 
 	// Store the infos of the last hop
-	var trhops []ReducedTrHopItem
+	trhops := make([]ReducedTrHopItem, 0, len(result))
 
 	for i, hop := range result {
 		rth := ReducedTrHopItem{HopIa: hop.HopIa,

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -36,6 +36,7 @@ import (
 	log "github.com/inconshreveable/log15"
 	"github.com/kormat/fmt15"
 	_ "github.com/mattn/go-sqlite3"
+
 	lib "github.com/netsec-ethz/scion-apps/webapp/lib"
 	model "github.com/netsec-ethz/scion-apps/webapp/models"
 	. "github.com/netsec-ethz/scion-apps/webapp/util"


### PR DESCRIPTION
Enable many golangci-linters that seem somewhat useful and don't show
ridiculous numbers of issues out of the gate.

- update golangci-lint to latest 1.43.0
- consistent import ordering enforced by gci
- nilnil and nilerr linters actually found various bugs where a nil
  error was returned after detecting an error.
- fix issues in bwtester and ssh so that exclude-rules can be removed:
  - bwtester: requires removing the dot-import of the bwtestlib. For
    this, renamed it to shorter `bwtest` and renamed various items in it
    to remove the redundant Bwtest from the name.
  - ssh: minimally handle various errors, or explicitly ignore them
    Reply the error state for `WantReply` requests.
- enable lint for examples (and fix all issues)

-----

It's clear that enabling more linters won't magically turn bad code good. But it probably doesn't hurt either, and it did find a few bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/213)
<!-- Reviewable:end -->
