### PR TITLE
example-helloquic: fix handling ApplicationError

### DIFF
--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -73,7 +73,8 @@ func runServer(listen netaddr.IPPort) error {
 		fmt.Println("New session", session.RemoteAddr())
 		go func() {
 			err := workSession(session)
-			if err != nil && !errors.Is(err, &quic.ApplicationError{}) {
+			var errApplication *quic.ApplicationError
+			if err != nil && !(errors.As(err, &errApplication) && errApplication.ErrorCode == 0) {
 				fmt.Println("Error in session", session.RemoteAddr(), err)
 			}
 		}()


### PR DESCRIPTION
The ApplicationError code 0 indicates no error, just that the client
closed the session successfully. This error is thus intended to be
suppressed from the logging. Detection of this ApplicationError
was just not working, it used `errors.Is` instead of `errors.As`.

Closes #219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/221)
<!-- Reviewable:end -->
