### PR TITLE
pan: add support for Colibri path type packets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,4 @@ require (
 	inet.af/netaddr v0.0.0-20210903134321-85fa6c94624e
 )
 
-replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220310075459-9aaced056448
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220407132138-98d64387e90d

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/netsec-ethz/rains v0.5.0 h1:5x+C7aIVZNLtlonyA5JWUXR+MQXMuJzxK8PwnLWQV1E=
 github.com/netsec-ethz/rains v0.5.0/go.mod h1:+H9/DeJoYmFtcpLqFUJFQgALVWO675XdBZJdALL5ltU=
-github.com/netsec-ethz/scion v0.6.1-0.20220310075459-9aaced056448 h1:G9+NxqzAa1SuI5/p65NZg3YO+qZtivvfsOdBpDF8Mxk=
-github.com/netsec-ethz/scion v0.6.1-0.20220310075459-9aaced056448/go.mod h1:2VD/l6X9pD7rhGYxras9cwAB4cJejS+z6XWFD/dPZ2I=
+github.com/netsec-ethz/scion v0.6.1-0.20220407132138-98d64387e90d h1:emKEHjTVWMZ6Yc2D9ZkBBCUe4tS3a2JzA+xop35vZ44=
+github.com/netsec-ethz/scion v0.6.1-0.20220407132138-98d64387e90d/go.mod h1:2VD/l6X9pD7rhGYxras9cwAB4cJejS+z6XWFD/dPZ2I=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/pkg/pan/path.go
+++ b/pkg/pan/path.go
@@ -55,18 +55,17 @@ type ForwardingPath struct {
 }
 
 func (p ForwardingPath) forwardingPathInfo() (forwardingPathInfo, error) {
-	var raw []byte
 	switch dataplanePath := p.dataplanePath.(type) {
 	case snet.RawReplyPath:
 		switch dataplanePath.Path.Type() {
 		case scion.PathType:
-			raw = make([]byte, dataplanePath.Path.Len())
+			raw := make([]byte, dataplanePath.Path.Len())
 			if err := dataplanePath.Path.SerializeTo(raw); err != nil {
 				return forwardingPathInfo{}, err
 			}
 			return fwPathInfoSCION(raw)
 		case colibri.PathType:
-			raw = make([]byte, dataplanePath.Path.Len())
+			raw := make([]byte, dataplanePath.Path.Len())
 			if err := dataplanePath.Path.SerializeTo(raw); err != nil {
 				return forwardingPathInfo{}, err
 			}
@@ -77,20 +76,16 @@ func (p ForwardingPath) forwardingPathInfo() (forwardingPathInfo, error) {
 	case snet.RawPath:
 		switch dataplanePath.PathType {
 		case scion.PathType:
-			raw = dataplanePath.Raw
-			return fwPathInfoSCION(raw)
+			return fwPathInfoSCION(dataplanePath.Raw)
 		case colibri.PathType:
-			raw = dataplanePath.Raw
-			return fwPathInfoColibri(raw)
+			return fwPathInfoColibri(dataplanePath.Raw)
 		default:
 			return forwardingPathInfo{}, fmt.Errorf("unsupported path type %v inside RawPath", dataplanePath.PathType)
 		}
 	case snetpath.SCION:
-		raw = dataplanePath.Raw
-		return fwPathInfoSCION(raw)
+		return fwPathInfoSCION(dataplanePath.Raw)
 	case snetpath.Colibri:
-		raw = dataplanePath.Raw
-		return fwPathInfoColibri(raw)
+		return fwPathInfoColibri(dataplanePath.Raw)
 	default:
 		return forwardingPathInfo{}, fmt.Errorf("unsupported path type %T", p.dataplanePath)
 	}

--- a/pkg/pan/path.go
+++ b/pkg/pan/path.go
@@ -188,7 +188,7 @@ func expiryFromDecodedSCION(sp scion.Decoded) time.Time {
 }
 
 func expiryFromDecodedColibri(cp colibri.ColibriPath) time.Time {
-	return time.Unix(libcolibri.TickDuration * int64(cp.InfoField.ExpTick), 0)
+	return time.Unix(libcolibri.TickDuration*int64(cp.InfoField.ExpTick), 0)
 }
 
 func interfaceIDsFromDecodedSCION(sp scion.Decoded) []IfID {
@@ -229,14 +229,14 @@ func interfaceIDsFromDecodedSCION(sp scion.Decoded) []IfID {
 }
 
 func interfaceIDsFromDecodedColibri(cp colibri.ColibriPath) []IfID {
-	ifIDs := make([]IfID, 0, 2*len(cp.HopFields) - 2)
+	ifIDs := make([]IfID, 0, 2*len(cp.HopFields)-2)
 
 	nrHops := len(cp.HopFields)
 	for h, hop := range cp.HopFields {
 		if h > 0 {
 			ifIDs = append(ifIDs, IfID(hop.IngressId))
 		}
-		if h < nrHops - 1 {
+		if h < nrHops-1 {
 			ifIDs = append(ifIDs, IfID(hop.EgressId))
 		}
 	}

--- a/pkg/pan/path_test.go
+++ b/pkg/pan/path_test.go
@@ -97,21 +97,21 @@ func TestInterfacesFromDecodedColibri(t *testing.T) {
 	cp := colibri.ColibriPath{
 		InfoField: &colibri.InfoField{},
 		HopFields: []*colibri.HopField{
-			&colibri.HopField{
+			{
 				IngressId: 0,
-				EgressId: 1,
+				EgressId:  1,
 			},
-			&colibri.HopField{
+			{
 				IngressId: 2,
-				EgressId: 3,
+				EgressId:  3,
 			},
-			&colibri.HopField{
+			{
 				IngressId: 4,
-				EgressId: 5,
+				EgressId:  5,
 			},
-			&colibri.HopField{
+			{
 				IngressId: 6,
-				EgressId: 0,
+				EgressId:  0,
 			},
 		},
 	}

--- a/pkg/pan/path_test.go
+++ b/pkg/pan/path_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/slayers/path/colibri"
 	"github.com/scionproto/scion/go/lib/slayers/path/scion"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,7 +76,7 @@ func TestPathString(t *testing.T) {
 	}
 }
 
-func TestInterfacesFromDecoded(t *testing.T) {
+func TestInterfacesFromDecodedSCION(t *testing.T) {
 	// Not a great test case...
 	rawPath := []byte("\x00\x00\x20\x80\x00\x00\x01\x11\x00\x00\x01\x00\x01\x00\x02\x22\x00\x00" +
 		"\x01\x00\x00\x3f\x00\x01\x00\x00\x01\x02\x03\x04\x05\x06\x00\x3f\x00\x03\x00\x02\x01\x02\x03" +
@@ -87,8 +88,43 @@ func TestInterfacesFromDecoded(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	ifaces := interfaceIDsFromDecoded(sp)
+	ifaces := interfaceIDsFromDecodedSCION(sp)
 	expected := []IfID{1, 2, 2, 1}
+	assert.Equal(t, ifaces, expected)
+}
+
+func TestInterfacesFromDecodedColibri(t *testing.T) {
+	cp := colibri.ColibriPath{
+		InfoField: &colibri.InfoField{},
+		HopFields: []*colibri.HopField{
+			&colibri.HopField{
+				IngressId: 0,
+				EgressId: 1,
+			},
+			&colibri.HopField{
+				IngressId: 2,
+				EgressId: 3,
+			},
+			&colibri.HopField{
+				IngressId: 4,
+				EgressId: 5,
+			},
+			&colibri.HopField{
+				IngressId: 6,
+				EgressId: 0,
+			},
+		},
+	}
+
+	// Forward direction
+	ifaces := interfaceIDsFromDecodedColibri(cp)
+	expected := []IfID{1, 2, 3, 4, 5, 6}
+	assert.Equal(t, ifaces, expected)
+
+	// Backward direction (R=1)
+	cp.InfoField.R = true
+	ifaces = interfaceIDsFromDecodedColibri(cp)
+	expected = []IfID{6, 5, 4, 3, 2, 1}
 	assert.Equal(t, ifaces, expected)
 }
 


### PR DESCRIPTION
Enable the pan library to handle Colibri path type packets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/225)
<!-- Reviewable:end -->
