### PR TITLE
Add strict flag to example fileserver

### DIFF
--- a/_examples/shttp/fileserver/main.go
+++ b/_examples/shttp/fileserver/main.go
@@ -31,7 +31,7 @@ func main() {
 	certFile := flag.String("cert", "", "Path to TLS server certificate for optional https")
 	keyFile := flag.String("key", "", "Path to TLS server key for optional https")
 	strictSCION := *flag.String("strict", "", "Add `Strict-SCION` header "+
-		"with provided property if not present")
+		"with provided property, replaces any existing value for that header")
 	flag.Parse()
 
 	handler := handlers.LoggingHandler(
@@ -39,8 +39,8 @@ func main() {
 		func(h http.Handler) http.HandlerFunc {
 			return func(w http.ResponseWriter, r *http.Request) {
 				if strictSCION != "" {
-					// Set Strict-SCION response header
-					w.Header().Add("Strict-SCION", strictSCION)
+					// Set Strict-SCION response header, overwrites any existing header for that key
+					w.Header().Set("Strict-SCION", strictSCION)
 				}
 				// Serve
 				h.ServeHTTP(w, r)

--- a/_examples/shttp/fileserver/main.go
+++ b/_examples/shttp/fileserver/main.go
@@ -30,17 +30,17 @@ import (
 func main() {
 	certFile := flag.String("cert", "", "Path to TLS server certificate for optional https")
 	keyFile := flag.String("key", "", "Path to TLS server key for optional https")
-	strictSCION := *flag.String("strict", "", "Add `Strict-SCION` header "+
-		"with provided property, replaces any existing value for that header")
+	strictSCION := flag.String("strict", "", "Sets the `Strict-SCION` header value; "+
+		"directives similar as in the HSTS header are to be defined by this flag")
 	flag.Parse()
 
 	handler := handlers.LoggingHandler(
 		os.Stdout,
 		func(h http.Handler) http.HandlerFunc {
 			return func(w http.ResponseWriter, r *http.Request) {
-				if strictSCION != "" {
+				if *strictSCION != "" {
 					// Set Strict-SCION response header, overwrites any existing header for that key
-					w.Header().Set("Strict-SCION", strictSCION)
+					w.Header().Set("Strict-SCION", *strictSCION)
 				}
 				// Serve
 				h.ServeHTTP(w, r)


### PR DESCRIPTION
Add flag strict to example file server for setting the Strict-SCION header if desired to all replies,
explicitly signaling (Strict-)SCION support to clients via the response header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/231)
<!-- Reviewable:end -->
