### PR TITLE
Add Strict-SCION header support to web-gateway

### DIFF
--- a/web-gateway/main.go
+++ b/web-gateway/main.go
@@ -39,8 +39,8 @@ import (
 )
 
 func main() {
-	strictSCION := kingpin.Flag("strict", "Add `Strict-SCION` header "+
-		"with provided property value if not present").String()
+	strictSCION := kingpin.Flag("strict", "Add `Strict-SCION` header with provided value"+
+		" (similar to HSTS directives) if not already present").String()
 	hosts := kingpin.Arg("hosts", "Hostnames for hosts to proxy").Required().Strings()
 	kingpin.Parse()
 


### PR DESCRIPTION
Support setting additional HTTP Header Strict-SCION for HTTP traffic on the web-gateway via a 'strict' flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/232)
<!-- Reviewable:end -->
