### PR TITLE
adapt hellodrkey

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -12,6 +12,6 @@ require (
 	inet.af/netaddr v0.0.0-20210903134321-85fa6c94624e
 )
 
-replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220929101513-2408583f35d1
 
 replace github.com/netsec-ethz/scion-apps => ../

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/netsec-ethz/scion-apps v0.5.1-0.20220504120040-79211109ed3f
 	github.com/scionproto/scion v0.6.1-0.20220202161514-5883c725f748
 	google.golang.org/grpc v1.40.0
+	google.golang.org/protobuf v1.27.1
 	inet.af/netaddr v0.0.0-20210903134321-85fa6c94624e
 )
 
-replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220422080039-25976708fd6b
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60
 
 replace github.com/netsec-ethz/scion-apps => ../

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -462,8 +462,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/netsec-ethz/rains v0.5.0 h1:5x+C7aIVZNLtlonyA5JWUXR+MQXMuJzxK8PwnLWQV1E=
 github.com/netsec-ethz/rains v0.5.0/go.mod h1:+H9/DeJoYmFtcpLqFUJFQgALVWO675XdBZJdALL5ltU=
-github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60 h1:KZZCIj8IqbnvMqHPeL+NhoMWWlACBf7BIZ3enozqldk=
-github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60/go.mod h1:9EyDb3Bfn7kDmy6v+gHKwl2eIxFo3Reod4TwDaKY5zo=
+github.com/netsec-ethz/scion v0.6.1-0.20220929101513-2408583f35d1 h1:6u2UB/od3ZQFQpHYsf/ZsJssrGlXMCmlwqbT0sIXLLw=
+github.com/netsec-ethz/scion v0.6.1-0.20220929101513-2408583f35d1/go.mod h1:9EyDb3Bfn7kDmy6v+gHKwl2eIxFo3Reod4TwDaKY5zo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -462,8 +462,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/netsec-ethz/rains v0.5.0 h1:5x+C7aIVZNLtlonyA5JWUXR+MQXMuJzxK8PwnLWQV1E=
 github.com/netsec-ethz/rains v0.5.0/go.mod h1:+H9/DeJoYmFtcpLqFUJFQgALVWO675XdBZJdALL5ltU=
-github.com/netsec-ethz/scion v0.6.1-0.20220422080039-25976708fd6b h1:cLQzuQ51QiGVdwGgUZdFh6QyoXAM64YkdWqdGjBgfSg=
-github.com/netsec-ethz/scion v0.6.1-0.20220422080039-25976708fd6b/go.mod h1:9EyDb3Bfn7kDmy6v+gHKwl2eIxFo3Reod4TwDaKY5zo=
+github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60 h1:KZZCIj8IqbnvMqHPeL+NhoMWWlACBf7BIZ3enozqldk=
+github.com/netsec-ethz/scion v0.6.1-0.20220908152129-737e910b8d60/go.mod h1:9EyDb3Bfn7kDmy6v+gHKwl2eIxFo3Reod4TwDaKY5zo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/_examples/hellodrkey/README.md
+++ b/_examples/hellodrkey/README.md
@@ -8,14 +8,14 @@ The application mimics the behavior using DRKey that would be observed by both a
 The client uses the slow path to obtain a DRKey, and the server uses the fast path.
 
 Slow path (client):
-1. Obtain a connection to the designated `sciondForClient` and encapsulate it in the `Client` class.
+1. Obtain a connection to the designated Control Service and encapsulate it in the `Client` class.
 1. Obtain the metadata for the DRKey.
 1. Request the DRKey with that metadata.
 
 Fast path (server):
-1. Obtain a connection to the designated `sciondForServer` and encapsulate it in the `Server` class.
-1. Obtain the Secret Value (SV) for the designated protocol.
-1. Derive the DRKey with the SV and the metadata.
+1. Obtain a connection to the designated Control Service and encapsulate it in the `Server` class.
+1. Obtain the Secret Value for that metadata. The Secret Value does not change with the destination host.
+1. Derive the DRKey with the SecretValue and the metadata.
 
 Both slow and fast paths should obtain the same key.
 And both slow and fast path are measured for performance and their times displayed at the end.
@@ -26,12 +26,9 @@ For this example to work, you must configure your devel SCION with an appropriat
 Follow these steps:
 
 1. Create a local topology with the `tiny.topo` description: `./scion.sh topology -c ./topology/tiny.topo`.
-1. Allow the server of the example setup to obtain the Secret Value (SV) for the DNS protocol.
-   Edit `gen/ASff00_0_111/cs1-ff00_0_111-1.toml` and include an entry for `dns` under `drkey.delegation`:
-
-   ```toml
-   [drkey.delegation]
-   dns = [ "127.0.0.1",]
-   ```
-
-1. Start scion with `./scion.sh start` and run hellodrkey.
+1. Add the following entry to `gen/ASff00_0_111/cs1-ff00_0_111-1.toml`:
+```
+[drkey.delegation]
+scmp = [ "<application network address>",] (e.g., scmp = [ "127.0.0.1",] )
+```
+1. Restart scion with `./scion.sh stop; ./scion.sh start nobuild` and run hellodrkey.

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -97,7 +97,9 @@ func NewServer(ctx context.Context, sciondPath string) Server {
 // The IP address of the server must be explicitly allowed to abtain this SV
 // from the the control server.
 func (s Server) fetchSV(ctx context.Context, meta drkey.SVMeta) drkey.SV {
-	// Obtain CS address from scion daemon
+	// Obtain CS address from scion daemon. Note there's no need to use
+	// the daemon as long as a valid address could be passed to the dialing
+	// function.
 	svcs, err := s.daemon.SVCInfo(ctx, nil)
 	check(err)
 	cs := svcs[addr.SvcCS]

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -21,9 +21,6 @@ import (
 	"net"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/daemon"
 	"github.com/scionproto/scion/go/lib/drkey"
@@ -31,6 +28,8 @@ import (
 	"github.com/scionproto/scion/go/lib/scrypto/cppki"
 	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
 	dkpb "github.com/scionproto/scion/go/pkg/proto/drkey"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // check just ensures the error is nil, or complains and quits

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -91,9 +91,9 @@ func NewServer(ctx context.Context, sciondPath string) Server {
 	}
 }
 
-// fetchSV obtain the Secret Value (SV) for the selected protocol/epoch.
+// fetchSV obtains the Secret Value (SV) for the selected protocol/epoch.
 // From this SV, all keys for this protocol/epoch can be derived locally.
-// The IP address of the server must be explicitly allowed to abtain this SV
+// The IP address of the server must be explicitly allowed to obtain this SV
 // from the the control server.
 func (s Server) fetchSV(ctx context.Context, meta drkey.SVMeta) drkey.SV {
 	// Obtain CS address from scion daemon. Note there's no need to use

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -92,7 +92,7 @@ func NewServer(ctx context.Context, sciondPath string) Server {
 	}
 }
 
-// fetchSV obtains the Secret Value (SV) for the selected protocol/epoch.
+// fetchSV obtain the Secret Value (SV) for the selected protocol/epoch.
 // From this SV, all keys for this protocol/epoch can be derived locally.
 // The IP address of the server must be explicitly allowed to abtain this SV
 // from the the control server.

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -21,9 +21,6 @@ import (
 	"net"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/daemon"
 	"github.com/scionproto/scion/go/lib/drkey"
@@ -31,6 +28,8 @@ import (
 	"github.com/scionproto/scion/go/lib/scrypto/cppki"
 	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
 	dkpb "github.com/scionproto/scion/go/pkg/proto/drkey"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // check just ensures the error is nil, or complains and quits
@@ -202,13 +201,6 @@ func main() {
 	durationServer := time.Since(t0)
 
 	fmt.Printf("Server,\thost key = %s\tduration = %s\n", hex.EncodeToString(serverKey.Key[:]), durationServer)
-}
-
-func secretValueMetaToProtoRequest(meta drkey.SVMeta) (*dkpb.SVRequest, error) {
-	return &dkpb.SVRequest{
-		ValTime:    timestamppb.New(meta.Validity),
-		ProtocolId: dkpb.Protocol(meta.ProtoId),
-	}, nil
 }
 
 func getSecretFromReply(

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -31,7 +31,6 @@ import (
 	"github.com/scionproto/scion/go/lib/scrypto/cppki"
 	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
 	dkpb "github.com/scionproto/scion/go/pkg/proto/drkey"
-	"github.com/scionproto/scion/pkg/daemon"
 )
 
 // check just ensures the error is nil, or complains and quits

--- a/_examples/hellodrkey/hellodrkey.go
+++ b/_examples/hellodrkey/hellodrkey.go
@@ -18,14 +18,20 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/scionproto/scion/go/lib/addr"
-	drkeyctrl "github.com/scionproto/scion/go/lib/ctrl/drkey"
 	"github.com/scionproto/scion/go/lib/daemon"
 	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/drkey/fetcher"
+	"github.com/scionproto/scion/go/lib/scrypto/cppki"
 	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
-	"google.golang.org/grpc"
+	dkpb "github.com/scionproto/scion/go/pkg/proto/drkey"
+	"github.com/scionproto/scion/pkg/daemon"
 )
 
 // check just ensures the error is nil, or complains and quits
@@ -35,21 +41,42 @@ func check(e error) {
 	}
 }
 
-type Client struct {
+type dialer struct {
 	daemon daemon.Connector
+}
+
+func (d *dialer) Dial(ctx context.Context, _ net.Addr) (*grpc.ClientConn, error) {
+	// Obtain CS address from scion daemon
+	svcs, err := d.daemon.SVCInfo(ctx, nil)
+	check(err)
+	cs := svcs[addr.SvcCS]
+	if len(cs) == 0 {
+		panic("no CS svc address")
+	}
+
+	// Contact CS directly for SV
+	return grpc.DialContext(ctx, cs, grpc.WithInsecure())
+}
+
+type Client struct {
+	fetcher *fetcher.Fetcher
 }
 
 func NewClient(ctx context.Context, sciondPath string) Client {
 	daemon, err := daemon.NewService(sciondPath).Connect(ctx)
 	check(err)
 	return Client{
-		daemon: daemon,
+		fetcher: &fetcher.Fetcher{
+			Dialer: &dialer{
+				daemon: daemon,
+			},
+		},
 	}
 }
 
 func (c Client) HostHostKey(ctx context.Context, meta drkey.HostHostMeta) drkey.HostHostKey {
 	// get L2 key: (slow path)
-	key, err := c.daemon.DRKeyGetHostHostKey(ctx, meta)
+	key, err := c.fetcher.HostHost(ctx, meta)
 	check(err)
 	return key
 }
@@ -75,29 +102,38 @@ func (s Server) fetchSV(ctx context.Context, meta drkey.SVMeta) drkey.SV {
 	svcs, err := s.daemon.SVCInfo(ctx, nil)
 	check(err)
 	cs := svcs[addr.SvcCS]
+	if len(cs) == 0 {
+		panic("no CS svc address")
+	}
 
 	// Contact CS directly for SV
 	conn, err := grpc.DialContext(ctx, cs, grpc.WithInsecure())
 	check(err)
 	defer conn.Close()
 	client := cppb.NewDRKeyIntraServiceClient(conn)
-	protoReq, err := drkeyctrl.SVMetaToProtoRequest(meta)
+
+	rep, err := client.SV(ctx, &dkpb.SVRequest{
+		ValTime:    timestamppb.New(meta.Validity),
+		ProtocolId: dkpb.Protocol(meta.ProtoId),
+	})
 	check(err)
-	rep, err := client.SV(ctx, protoReq)
-	check(err)
-	key, err := drkeyctrl.GetSVFromReply(meta.ProtoId, rep)
+	key, err := getSecretFromReply(meta.ProtoId, rep)
 	check(err)
 	return key
 }
 
 func (s Server) HostHostKey(sv drkey.SV, meta drkey.HostHostMeta) drkey.HostHostKey {
-	var deriver drkey.SpecificDeriver
+	deriver := (&drkey.SpecificDeriver{})
 	lvl1, err := deriver.DeriveLvl1(drkey.Lvl1Meta{
-		DstIA: meta.DstIA,
+		Validity: meta.Validity,
+		ProtoId:  meta.ProtoId,
+		SrcIA:    meta.SrcIA,
+		DstIA:    meta.DstIA,
 	}, sv.Key)
 	check(err)
 	asHost, err := deriver.DeriveHostAS(drkey.HostASMeta{
-		SrcHost: meta.SrcHost,
+		Lvl2Meta: meta.Lvl2Meta,
+		SrcHost:  meta.SrcHost,
 	}, lvl1)
 	check(err)
 	hosthost, err := deriver.DeriveHostToHost(meta.DstHost, asHost)
@@ -122,7 +158,7 @@ func main() {
 	const sciondForClient = "[fd00:f00d:cafe::7f00:c]:30255"
 	clientIA, err := addr.ParseIA("1-ff00:0:112")
 	check(err)
-	const clientIP = "fd00:f00d:cafe::7f00:c"
+	const clientIP = "fd00:f00d:cafe::7f00:b"
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancelF()
@@ -130,7 +166,7 @@ func main() {
 	// meta describes the key that both client and server derive
 	meta := drkey.HostHostMeta{
 		Lvl2Meta: drkey.Lvl2Meta{
-			ProtoId: drkey.DNS,
+			ProtoId: drkey.SCMP,
 			// Validity timestamp; both sides need to use the same time stamp when deriving the key
 			// to ensure they derive keys for the same epoch.
 			// Usually this is coordinated by means of a timestamp in the message.
@@ -167,4 +203,38 @@ func main() {
 	durationServer := time.Since(t0)
 
 	fmt.Printf("Server,\thost key = %s\tduration = %s\n", hex.EncodeToString(serverKey.Key[:]), durationServer)
+}
+
+func secretValueMetaToProtoRequest(meta drkey.SVMeta) (*dkpb.SVRequest, error) {
+	return &dkpb.SVRequest{
+		ValTime:    timestamppb.New(meta.Validity),
+		ProtocolId: dkpb.Protocol(meta.ProtoId),
+	}, nil
+}
+
+func getSecretFromReply(
+	proto drkey.Protocol,
+	rep *dkpb.SVResponse,
+) (drkey.SV, error) {
+
+	err := rep.EpochBegin.CheckValid()
+	if err != nil {
+		return drkey.SV{}, err
+	}
+	err = rep.EpochEnd.CheckValid()
+	if err != nil {
+		return drkey.SV{}, err
+	}
+	epoch := drkey.Epoch{
+		Validity: cppki.Validity{
+			NotBefore: rep.EpochBegin.AsTime(),
+			NotAfter:  rep.EpochEnd.AsTime(),
+		},
+	}
+	returningKey := drkey.SV{
+		ProtoId: proto,
+		Epoch:   epoch,
+	}
+	copy(returningKey.Key[:], rep.Key)
+	return returningKey, nil
 }


### PR DESCRIPTION
This PR adapts `_examples/hellodrkey` to use the DRKey library code to fetch DRKeys, i.e., bypassing the scionD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/235)
<!-- Reviewable:end -->
