### PR TITLE
Fix linting _examples module

### DIFF
--- a/_examples/.golangci.yml
+++ b/_examples/.golangci.yml
@@ -1,0 +1,50 @@
+# Configuration for golangci-lint for scion-apps.
+# See https://github.com/golangci/golangci-lint#config-file
+
+linters:
+  enable:
+    # enabled by default:
+    #- deadcode
+    #- errcheck
+    #- gosimple
+    #- govet
+    #- ineffassign
+    #- staticcheck
+    #- structcheck
+    #- typecheck
+    #- unused
+    #- varcheck
+    - asciicheck
+    - bidichk
+    - contextcheck
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exportloopref
+    - gci
+    - gofmt
+    - ifshort
+    - importas
+    - makezero
+    - misspell
+    - nilerr
+    - nilnil
+    - nolintlint
+    - prealloc
+    - stylecheck
+    - thelper
+    - wastedassign
+    - tenv
+
+issues:
+  max-same-issues: 0
+
+linters-settings:
+  gci:
+    local-prefixes: examples
+  exhaustive:
+    default-signifies-exhaustive: true
+
+run:
+  build-tags: integration

--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -25,10 +25,9 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go"
-	"inet.af/netaddr"
-
 	"github.com/netsec-ethz/scion-apps/pkg/pan"
 	"github.com/netsec-ethz/scion-apps/pkg/quicutil"
+	"inet.af/netaddr"
 )
 
 func main() {

--- a/_examples/helloworld/helloworld.go
+++ b/_examples/helloworld/helloworld.go
@@ -22,9 +22,8 @@ import (
 	"os"
 	"time"
 
-	"inet.af/netaddr"
-
 	"github.com/netsec-ethz/scion-apps/pkg/pan"
+	"inet.af/netaddr"
 )
 
 func main() {

--- a/_examples/shttp/fileserver/main.go
+++ b/_examples/shttp/fileserver/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
-
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 

--- a/_examples/shttp/proxy/main.go
+++ b/_examples/shttp/proxy/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
-
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 

--- a/_examples/shttp/server/main.go
+++ b/_examples/shttp/server/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
-
 	"github.com/netsec-ethz/scion-apps/pkg/shttp"
 )
 


### PR DESCRIPTION
add golangci.yml in examples to solve gci-ed warnings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/237)
<!-- Reviewable:end -->
