### PR TITLE
skip: update proxy to the last version of the extension

### DIFF
--- a/pkg/pan/policy.go
+++ b/pkg/pan/policy.go
@@ -118,6 +118,10 @@ func (s Sequence) Filter(paths []*Path) []*Path {
 	return ps
 }
 
+func (s Sequence) String() string {
+	return s.sequence.String()
+}
+
 // ACL is a policy filtering paths matching an ACL pattern. The ACL pattern is
 // an ordered list of allow/deny actions over hop predicates.
 // See https://scion.docs.anapaya.net/en/latest/PathPolicy.html#acl.

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -33,6 +33,8 @@ type Conn interface {
 	// ReadVia reads a message and returns the (return-)path via which the
 	// message was received.
 	ReadVia(b []byte) (int, *Path, error)
+
+	GetPath() *Path
 }
 
 // DialUDP opens a SCION/UDP socket, connected to the remote address.
@@ -94,6 +96,10 @@ func (c *dialedConn) SetPolicy(policy Policy) {
 
 func (c *dialedConn) LocalAddr() net.Addr {
 	return c.local
+}
+
+func (c *dialedConn) GetPath() *Path {
+	return c.selector.Path()
 }
 
 func (c *dialedConn) RemoteAddr() net.Addr {

--- a/pkg/quicutil/single.go
+++ b/pkg/quicutil/single.go
@@ -56,11 +56,11 @@ type SingleStreamListener struct {
 
 func (l SingleStreamListener) Accept() (net.Conn, error) {
 	ctx := context.Background()
-	session, err := l.Listener.Accept(ctx)
+	connection, err := l.Listener.Accept(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return NewSingleStream(session)
+	return NewSingleStream(connection)
 }
 
 // SingleStream implements an opaque, bi-directional data stream using QUIC,
@@ -68,11 +68,11 @@ func (l SingleStreamListener) Accept() (net.Conn, error) {
 // A SingleStream is either created by
 //
 //   - on the client side: quic.Dial and then immediately NewSingleStream(sess)
-//     with the obtained session
+//     with the obtained connection
 //   - on the listener side: quic.Listener wrapped in SingleStreamListener, which
 //     returns SingleStream from Accept.
 type SingleStream struct {
-	Session       quic.Connection
+	Connection    quic.Connection
 	sendStream    quic.SendStream
 	receiveStream quic.ReceiveStream
 	readDeadline  time.Time
@@ -80,29 +80,29 @@ type SingleStream struct {
 	onceOK        sync.Once
 }
 
-func NewSingleStream(session quic.Connection) (*SingleStream, error) {
-	sendStream, err := session.OpenUniStream()
+func NewSingleStream(connection quic.Connection) (*SingleStream, error) {
+	sendStream, err := connection.OpenUniStream()
 	if err != nil {
 		return nil, err
 	}
 	return &SingleStream{
-		Session:       session,
+		Connection:    connection,
 		sendStream:    sendStream,
 		receiveStream: nil,
 	}, nil
 }
 
 func (s *SingleStream) LocalAddr() net.Addr {
-	return s.Session.LocalAddr()
+	return s.Connection.LocalAddr()
 }
 
 func (s *SingleStream) GetPath() *pan.Path {
-	if s.Session == nil {
+	if s.Connection == nil {
 		// XXX(JordiSubira): To be refactored when proper support
 		// for retrieving path information.
 		return nil
 	}
-	quicSession, ok := s.Session.(*pan.QUICSession)
+	quicSession, ok := s.Connection.(*pan.QUICSession)
 	if !ok {
 		// XXX(JordiSubira): To be refactored when proper support
 		// for retrieving path information.
@@ -112,7 +112,7 @@ func (s *SingleStream) GetPath() *pan.Path {
 }
 
 func (s *SingleStream) RemoteAddr() net.Addr {
-	return s.Session.RemoteAddr()
+	return s.Connection.RemoteAddr()
 }
 
 func (s *SingleStream) SetDeadline(t time.Time) error {
@@ -165,7 +165,7 @@ func (s *SingleStream) awaitReceiveStream() error {
 			ctx, cancel = context.WithDeadline(ctx, s.readDeadline)
 			defer cancel()
 		}
-		stream, err := s.Session.AcceptUniStream(ctx)
+		stream, err := s.Connection.AcceptUniStream(ctx)
 		if err != nil {
 			return err
 		}
@@ -179,7 +179,7 @@ func (s *SingleStream) awaitReceiveStream() error {
 
 func (s *SingleStream) sendOKSignal() {
 	s.onceOK.Do(func() {
-		okSignal, err := s.Session.OpenUniStream()
+		okSignal, err := s.Connection.OpenUniStream()
 		if err != nil {
 			return // otherwise ignore error here, what could we do?
 		}
@@ -192,14 +192,14 @@ func (s *SingleStream) awaitOKSignal(ctx context.Context) error {
 	defer s.mutex.Unlock()
 	// ensure we've accepted the actual receive stream first.
 	if s.receiveStream == nil {
-		stream, err := s.Session.AcceptUniStream(ctx)
+		stream, err := s.Connection.AcceptUniStream(ctx)
 		if err != nil {
 			return err
 		}
 		s.receiveStream = stream
 	}
 
-	_, err := s.Session.AcceptUniStream(ctx)
+	_, err := s.Connection.AcceptUniStream(ctx)
 	// We can ignore data arriving in on this stream -- we expect
 	// a single FIN, so a readeading will immediately give EOF.
 	// If that's not what we get, guess we can ignore it.
@@ -237,9 +237,9 @@ func (s *SingleStream) CloseSync(ctx context.Context) error {
 	_ = s.CloseRead()
 	// Await the OK-signal
 	if err := s.awaitOKSignal(ctx); err != nil {
-		return s.Session.CloseWithError(0x101, "shutdown error")
+		return s.Connection.CloseWithError(0x101, "shutdown error")
 	}
-	return s.Session.CloseWithError(0x0, "ok")
+	return s.Connection.CloseWithError(0x0, "ok")
 }
 
 func (s *SingleStream) Close() error {

--- a/pkg/quicutil/single.go
+++ b/pkg/quicutil/single.go
@@ -85,12 +85,11 @@ func NewSingleStream(session quic.Connection) (*SingleStream, error) {
 	if err != nil {
 		return nil, err
 	}
-	ss := &SingleStream{
+	return &SingleStream{
 		Session:       session,
 		sendStream:    sendStream,
 		receiveStream: nil,
-	}
-	return ss, nil
+	}, nil
 }
 
 func (s *SingleStream) LocalAddr() net.Addr {

--- a/pkg/quicutil/single.go
+++ b/pkg/quicutil/single.go
@@ -17,7 +17,6 @@ package quicutil
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -61,13 +60,7 @@ func (l SingleStreamListener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	// This is at the moment just for presentation purposes and needs to be
-	// rewritten in the end...
-	s, ok := session.(*pan.QUICSession)
-	if !ok {
-		return nil, fmt.Errorf("No Valid pan quic Session")
-	}
-	return NewSingleStream(s)
+	return NewSingleStream(session)
 }
 
 // SingleStream implements an opaque, bi-directional data stream using QUIC,
@@ -92,11 +85,12 @@ func NewSingleStream(session quic.Connection) (*SingleStream, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SingleStream{
+	ss := &SingleStream{
 		Session:       session,
 		sendStream:    sendStream,
 		receiveStream: nil,
-	}, nil
+	}
+	return ss, nil
 }
 
 func (s *SingleStream) LocalAddr() net.Addr {

--- a/skip/main.go
+++ b/skip/main.go
@@ -387,7 +387,7 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		destConn, err = net.DialTimeout("tcp", req.Host, 10*time.Second)
 	} else {
 		// CONNECT via SCION
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
 		defer cancel()
 		destConn, err = h.dialer.DialContext(ctx, "", req.Host)
 		if panConn, ok := destConn.(*quicutil.SingleStream); ok {

--- a/skip/main.go
+++ b/skip/main.go
@@ -387,7 +387,9 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		destConn, err = net.DialTimeout("tcp", req.Host, 10*time.Second)
 	} else {
 		// CONNECT via SCION
-		destConn, err = h.dialer.DialContext(context.Background(), "", req.Host)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		destConn, err = h.dialer.DialContext(ctx, "", req.Host)
 		if panConn, ok := destConn.(*quicutil.SingleStream); ok {
 			pathF = panConn.GetPath
 		}

--- a/skip/main.go
+++ b/skip/main.go
@@ -405,7 +405,7 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	clientConn, _, err := hijacker.Hijack()
 	if err != nil {
-		fmt.Println("verbose: ", "verbose: ", err.Error())
+		fmt.Println("verbose: ", err.Error())
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
@@ -422,6 +422,9 @@ func sequenceToPath(sequence pan.Sequence) string {
 }
 
 func pathToShortPath(path *pan.Path) string {
+	if path == nil {
+		return ""
+	}
 	if len(path.Metadata.Interfaces) == 0 {
 		return ""
 	}

--- a/skip/main.go
+++ b/skip/main.go
@@ -32,12 +32,14 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
 	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/scionproto/scion/go/lib/addr"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/netsec-ethz/scion-apps/pkg/pan"
@@ -93,6 +95,7 @@ func main() {
 
 	proxy := &proxyHandler{
 		transport: transport,
+		dialer:    dialer,
 	}
 	tunnelHandler := &tunnelHandler{
 		dialer: dialer,
@@ -268,26 +271,71 @@ func (h *policyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Check if acl
+	var policy pan.Policy
 	var acl pan.ACL
 	err = acl.UnmarshalJSON(body)
+	policy = &acl
 	if err != nil {
-		fmt.Println("verbose: ", err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		fmt.Println("verbose: not ACL format, trying Sequence format out")
+		var str string
+		err2 := json.Unmarshal(body, &str)
+		if err2 != nil {
+			fmt.Println("verbose: ", err.Error(), err2.Error())
+			http.Error(w, err.Error()+" "+err2.Error(), http.StatusBadRequest)
+			return
+		}
+		seqStr, err2 := parseShowPathToSeq(str)
+		if err2 != nil {
+			fmt.Println("verbose: ", err.Error(), err2.Error())
+			http.Error(w, err.Error()+" "+err2.Error(), http.StatusBadRequest)
+			return
+		}
+		sequence, err2 := pan.NewSequence(seqStr)
+		if err2 != nil {
+			fmt.Println("verbose: ", err.Error(), err2.Error())
+			http.Error(w, err.Error()+" "+err2.Error(), http.StatusBadRequest)
+			return
+		}
+		policy = sequence
 	}
-	h.output.SetPolicy(&acl)
-	fmt.Println("verbose: ", "ACL policy = ", acl.String())
+	h.output.SetPolicy(policy)
+	fmt.Println("verbose: ", "Policy = ", string(body))
 	w.WriteHeader(http.StatusOK)
 }
 
 type proxyHandler struct {
 	transport http.RoundTripper
+	dialer    *shttp.Dialer
 }
 
 func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	host := demunge(req.Host)
 	req.Host = host
 	req.URL.Host = host
+
+	// domain := req.URL.Hostname()
+	// policy := h.dialer.Policy
+	// sequence, ok := policy.(pan.Sequence)
+	// var pathUsage *PathUsage
+	// if ok {
+	// 	pu, ok := pathStats.data[domain]
+	// 	if !ok {
+	// 		pathUsage = &PathUsage{
+	// 			Received: 0,
+	// 			Strategy: "Geofenced", // TODO: This may be configured by the user
+	// 			Path:     sequenceToPath(sequence),
+	// 			Domain:   domain,
+	// 		}
+
+	// 		pathStats.Lock()
+	// 		pathStats.data[domain] = pathUsage
+	// 		pathStats.Unlock()
+	// 	} else {
+	// 		pathUsage = pu
+	// 		pathUsage.Path = sequenceToPath(sequence)
+	// 	}
+	// }
 
 	resp, err := h.transport.RoundTrip(req)
 	if err != nil {
@@ -330,7 +378,7 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var destConn net.Conn
 	var err error
 	enabled, _ := isSCIONEnabled(req.Context(), hostPort)
-	var path *pan.Path
+	var pathF func() *pan.Path
 	if !enabled {
 		// CONNECT via TCP/IP
 		destConn, err = net.DialTimeout("tcp", req.Host, 10*time.Second)
@@ -338,7 +386,7 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// CONNECT via SCION
 		destConn, err = h.dialer.DialContext(context.Background(), "", req.Host)
 		if panConn, ok := destConn.(*quicutil.SingleStream); ok {
-			path = panConn.GetPath()
+			pathF = panConn.GetPath
 		}
 	}
 	if err != nil {
@@ -364,8 +412,13 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// This is at the moment just for presentation purposes and needs to be
 	// rewritten in the end...
 	go transfer(destConn, clientConn, nil, req.URL.Hostname()) // We just count the received bytes for now
-	go transfer(clientConn, destConn, path, req.URL.Hostname())
+	go transfer(clientConn, destConn, pathF, req.URL.Hostname())
 
+}
+
+func sequenceToPath(sequence pan.Sequence) string {
+	s, _ := parseSequence(sequence)
+	return s
 }
 
 func pathToShortPath(path *pan.Path) string {
@@ -384,14 +437,17 @@ func pathToShortPath(path *pan.Path) string {
 	return b.String()
 }
 
-func transfer(dst io.WriteCloser, src io.ReadCloser, path *pan.Path, domain string) {
+func transfer(dst io.WriteCloser, src io.ReadCloser, pathF func() *pan.Path, domain string) {
 	defer dst.Close()
 	defer src.Close()
 	buf := make([]byte, 1024)
 	var written int64
 
+	// policy := h.dialer.Policy
+	// sequence, ok := policy.(pan.Sequence)
 	var pathUsage *PathUsage
-	if path != nil {
+	if pathF != nil {
+		path := pathF()
 		pu, ok := pathStats.data[domain]
 		if !ok {
 			pathUsage = &PathUsage{
@@ -407,14 +463,17 @@ func transfer(dst io.WriteCloser, src io.ReadCloser, path *pan.Path, domain stri
 			pathStats.Unlock()
 		} else {
 			pathUsage = pu
+			pathUsage.Path = pathToShortPath(path)
 		}
-
 	}
 
 	for {
 		nr, er := src.Read(buf)
 		if pathUsage != nil {
 			pathUsage.Received += int64(nr)
+		}
+		if pathF != nil && pathUsage != nil {
+			pathUsage.Path = pathToShortPath(pathF())
 		}
 
 		if nr > 0 {
@@ -491,4 +550,147 @@ func parseHostsFile(file *os.File) []string {
 		}
 	}
 	return hosts
+}
+
+type step struct {
+	IA      addr.IA
+	Ingress int
+	Egress  int
+}
+
+func stringToStep(s []string) (step, error) {
+	var step step
+	var err error
+	if len(s) != 3 {
+		return step, fmt.Errorf("wrong size %d != 3", len(s))
+	}
+	step.IA, err = addr.ParseIA(s[1])
+	if err != nil {
+		return step, err
+	}
+	step.Ingress, err = strconv.Atoi(s[0])
+	if err != nil {
+		return step, err
+	}
+	step.Egress, err = strconv.Atoi(s[2])
+	if err != nil {
+		return step, err
+	}
+	return step, nil
+}
+
+func stringToFirstStep(s []string) (step, error) {
+	var step step
+	var err error
+	if len(s) != 2 {
+		return step, fmt.Errorf("wrong size %d != 3", len(s))
+	}
+	step.IA, err = addr.ParseIA(s[0])
+	if err != nil {
+		return step, err
+	}
+	step.Egress, err = strconv.Atoi(s[1])
+	if err != nil {
+		return step, err
+	}
+	return step, nil
+}
+
+func stringToLastStep(s []string) (step, error) {
+	var step step
+	var err error
+	if len(s) != 2 {
+		return step, fmt.Errorf("wrong size %d != 2", len(s))
+	}
+	step.IA, err = addr.ParseIA(s[1])
+	if err != nil {
+		return step, err
+	}
+	step.Ingress, err = strconv.Atoi(s[0])
+	if err != nil {
+		return step, err
+	}
+	return step, nil
+}
+
+type steps []step
+
+func (s steps) ToSequenceStr() string {
+	// 19-ffaa:1:f5c 1>370 19-ffaa:0:1303 1>5 19-ffaa:0:1301 3>5 18-ffaa:0:1201 8>1 18-ffaa:0:1206 128>1 18-ffaa:1:feb
+	// 19-ffaa:1:f5c#1 19-ffaa:0:1303#370,1 19-ffaa:0:1301#5,3 18-ffaa:0:1201#5,8 18-ffaa:0:1206#1,128 18-ffaa:1:feb#1
+	b := &strings.Builder{}
+	for i, step := range s {
+		if i == 0 {
+			fmt.Fprintf(b, "%s #%d", step.IA.String(), step.Egress)
+			continue
+		}
+		if i == len(s)-1 {
+			fmt.Fprintf(b, " %s #%d", step.IA.String(), step.Ingress)
+			continue
+		}
+		fmt.Fprintf(b, " %s #%d,%d", step.IA.String(), step.Ingress, step.Egress)
+	}
+	return b.String()
+}
+
+func parseShowPaths(s string) (steps, error) {
+	iaInterfaces := strings.Split(s, ">")
+
+	if len(iaInterfaces) < 2 {
+		return nil, fmt.Errorf("iaInterfaces length %d < 2", len(iaInterfaces))
+	}
+
+	steps := make([]step, len(iaInterfaces))
+	var err error
+	// first IA + egress
+	steps[0], err = stringToFirstStep(strings.Split(iaInterfaces[0], " "))
+	if err != nil {
+		return nil, err
+	}
+	steps[len(steps)-1], err = stringToLastStep(strings.Split(iaInterfaces[len(steps)-1], " "))
+	if err != nil {
+		return nil, err
+	}
+	for i := 1; i < len(steps)-1; i++ {
+		steps[i], err = stringToStep(strings.Split(iaInterfaces[i], " "))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, step := range steps {
+		fmt.Printf("%s %d %d, ", step.IA.String(), step.Ingress, step.Egress)
+	}
+	return steps, nil
+}
+
+func parseShowPathToSeq(s string) (string, error) {
+	steps, err := parseShowPaths(s)
+	if err != nil {
+		return "", err
+	}
+	return steps.ToSequenceStr(), nil
+}
+
+func parseSequence(sequence pan.Sequence) (string, error) {
+	seqStr := sequence.String()
+	fmt.Println(seqStr)
+	seqStr = strings.Replace(seqStr, " #", "#", -1)
+	iaInterfaces := strings.Split(seqStr, " ")
+
+	if len(iaInterfaces) < 2 {
+		return "", fmt.Errorf("iaInterfaces length %d < 2", len(iaInterfaces))
+	}
+
+	b := &strings.Builder{}
+
+	for i, iaIfStr := range iaInterfaces {
+		iaIfs := strings.Split(iaIfStr, "#")
+		if i == 0 {
+			fmt.Fprintf(b, "%s", iaIfs[0])
+			continue
+		}
+		fmt.Fprintf(b, " -> %s", iaIfs[0])
+	}
+	return b.String(), nil
 }

--- a/skip/main.go
+++ b/skip/main.go
@@ -416,11 +416,6 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 }
 
-func sequenceToPath(sequence pan.Sequence) string {
-	s, _ := parseSequence(sequence)
-	return s
-}
-
 func pathToShortPath(path *pan.Path) string {
 	if path == nil {
 		return ""
@@ -673,27 +668,4 @@ func parseShowPathToSeq(s string) (string, error) {
 		return "", err
 	}
 	return steps.ToSequenceStr(), nil
-}
-
-func parseSequence(sequence pan.Sequence) (string, error) {
-	seqStr := sequence.String()
-	fmt.Println(seqStr)
-	seqStr = strings.Replace(seqStr, " #", "#", -1)
-	iaInterfaces := strings.Split(seqStr, " ")
-
-	if len(iaInterfaces) < 2 {
-		return "", fmt.Errorf("iaInterfaces length %d < 2", len(iaInterfaces))
-	}
-
-	b := &strings.Builder{}
-
-	for i, iaIfStr := range iaInterfaces {
-		iaIfs := strings.Split(iaIfStr, "#")
-		if i == 0 {
-			fmt.Fprintf(b, "%s", iaIfs[0])
-			continue
-		}
-		fmt.Fprintf(b, " -> %s", iaIfs[0])
-	}
-	return b.String(), nil
 }


### PR DESCRIPTION
This PR updates the backend proxy to support the last version of the browser-extension (see https://github.com/netsys-lab/scion-browser-extensions/pull/17).

Note for reviewers:
- This PR includes a little hack in the PAN network to export pan.QUICSession and thus have access to path information. If this hack takes longer to be corrected to merge to the master branch, I suggest to have a separate skip feature branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/242)
<!-- Reviewable:end -->
