### PR TITLE
Correct flags in helloworld and helloquic examples

### DIFF
--- a/_examples/helloquic/README.md
+++ b/_examples/helloquic/README.md
@@ -6,7 +6,7 @@ entire stream content and echos it back to the client.
 
 Server:
 ```
-go run helloquic.go -port 1234
+go run helloquic.go -listen 127.0.0.1:1234
 ```
 
 Client:

--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -40,7 +40,7 @@ func main() {
 	flag.Parse()
 
 	if (listen.Get().Port() > 0) == (len(*remoteAddr) > 0) {
-		check(fmt.Errorf("either specify -port for server or -remote for client"))
+		check(fmt.Errorf("either specify -listen for server or -remote for client"))
 	}
 
 	if listen.Get().Port() > 0 {

--- a/_examples/helloworld/README.md
+++ b/_examples/helloworld/README.md
@@ -5,7 +5,7 @@ which replies back.
 
 Server:
 ```
-go run helloworld.go -port 1234
+go run helloworld.go -listen 127.0.0.1:1234
 ```
 
 Client:


### PR DESCRIPTION
## Description

Running the examples with `go 1.19.13` off main branch: https://github.com/netsec-ethz/scion-apps/commit/4e358c45d580cda42c6f5c2685d594bdeca79988 (latest)

Trying to run `_example/helloworld` server with the example called out in the [README.md](https://github.com/netsec-ethz/scion-apps/blob/4e358c45d580cda42c6f5c2685d594bdeca79988/_examples/helloworld/README.md):
```
$ go run helloworld.go -port 1234
flag provided but not defined: -port
Usage of /tmp/go-build1940210333/b001/exe/helloworld:
  -count uint
        [Client] Number of messages to send (default 1)
  -listen value
        [Server] local IP:port to listen on
  -remote string
        [Client] Remote (i.e. the server's) SCION Address (e.g. 17-ffaa:1:1,[127.0.0.1]:12345)
```

`_example/helloworld` fix:

```
$ go run helloworld.go -listen 127.0.0.1:1234
18-ffaa:1:1,127.0.0.1:1234
```

Trying to run `_example/helloquic` server with its [README.md](https://github.com/netsec-ethz/scion-apps/blob/4e358c45d580cda42c6f5c2685d594bdeca79988/_examples/helloquic/README.md):
```
$ go run helloquic.go -port 1234
flag provided but not defined: -port
Usage of /tmp/go-build1941122250/b001/exe/helloquic:
  -count uint
        [Client] Number of messages to send (default 1)
  -listen value
        [Server] local IP:port to listen on
  -remote string
        [Client] Remote (i.e. the server's) SCION Address (e.g. 17-ffaa:1:1,[127.0.0.1]:12345)
exit status 2
```

`_example/helloquic` fix:

```
$ go run helloquic.go -listen 127.0.0.1:1234
18-ffaa:1:1,127.0.0.1:1234
```

Incorrect `-port` flag for error message in `_example/helloquic` when no flags are passed:

```
$ go run helloquic.go
Fatal error: either specify -port for server or -remote for client
exit status 1
```

`_example/helloquic` error message now refers to `-listen` flag
```
$ go run helloquic.go
Fatal error: either specify -listen for server or -remote for client
exit status 1
```

## Tests

`_example/helloworld` client is able to get a reply from the server:

```
$ go run helloworld.go -remote 18-ffaa:1:1,[127.0.0.1]:1234
Wrote 22 bytes.
Received reply: take it back! 17:03:32.3
```

`_example/helloquic` client is able to get a reply from the server:

```
$ go run helloquic.go -remote 18-ffaa:1:1,[127.0.0.1]:1234
gotcha: hi dude, 0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/245)
<!-- Reviewable:end -->
