### PR TITLE
Upgrade golangci-lint to version 1.57.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,15 @@ issues:
         - stylecheck
         - staticcheck
         - errcheck
+  # Bat is mostly copied third-party code that we don't care to fix
+  # Modifications are only (?) in bat/bat.go
+  exclude-dirs:
+    - bat/*/
+  exclude-files:
+    - bat/color.go
+    - bat/bench.go
+    - bat/pb.go
+    - bat/http.go
   max-same-issues: 0
 
 linters-settings:
@@ -55,12 +64,3 @@ linters-settings:
 
 run:
   build-tags: integration
-  # Bat is mostly copied third-party code that we don't care to fix
-  # Modifications are only (?) in bat/bat.go
-  skip-dirs:
-    - bat/*/
-  skip-files:
-    - bat/color.go
-    - bat/bench.go
-    - bat/pb.go
-    - bat/http.go

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 
 setup_lint:
 	@# Install golangci-lint (as dumb as this looks, this is the recommended way to install)
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ${DESTDIR} v1.53.3
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ${DESTDIR} v1.57.1
 
 lint:
 	@type golangci-lint > /dev/null || ( echo "golangci-lint not found. Install it manually or by running 'make setup_lint'."; exit 1 )

--- a/webapp/webapp.go
+++ b/webapp/webapp.go
@@ -691,11 +691,11 @@ func getTrcInfoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPathInfoHandler(w http.ResponseWriter, r *http.Request) {
-	lib.PathTopoHandler(w, r, &options, asCfg) //nolint:contextcheck
+	lib.PathTopoHandler(w, r, &options, asCfg)
 }
 
 func getAsTopoHandler(w http.ResponseWriter, r *http.Request) {
-	lib.AsTopoHandler(w, r, &options, asCfg) //nolint:contextcheck
+	lib.AsTopoHandler(w, r, &options, asCfg)
 }
 
 func getNodesHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This set of changes fixes various lint errors reported by version v1.53.3 of golangci-lint.