### PR TITLE
pan: fix GetPath if the connection is within the same AS

### DIFF
--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -98,6 +98,9 @@ func (c *dialedConn) LocalAddr() net.Addr {
 }
 
 func (c *dialedConn) GetPath() *Path {
+	if c.selector == nil {
+		return nil
+	}
 	return c.selector.Path()
 }
 


### PR DESCRIPTION
As the `c.selector` might be `nil` when [the remote AS and the local AS are the same](https://github.com/netsec-ethz/scion-apps/blob/master/pkg/pan/udp_dial.go#L62-L64), we should respect that in the path retrieval.

cc @JordiSubira 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/253)
<!-- Reviewable:end -->
