### PR TITLE
pan: fix pathPool query path procedure + close underlay UDPConn if QUIC session was not established successfully

### DIFF
--- a/pkg/pan/pool.go
+++ b/pkg/pan/pool.go
@@ -72,11 +72,11 @@ func (p *pathPool) paths(ctx context.Context, dstIA IA) ([]*Path, error) {
 	entry, ok := p.entries[dstIA]
 	p.entriesMutex.RUnlock()
 
-	if !ok || shouldRefresh(time.Now(), entry.earliestExpiry, entry.lastQuery) {
-		return p.queryPaths(ctx, dstIA)
+	if ok && !shouldRefresh(time.Now(), entry.earliestExpiry, entry.lastQuery) {
+		return append([]*Path{}, entry.paths...), nil
 	}
 
-	return append([]*Path{}, entry.paths...), nil
+	return p.queryPaths(ctx, dstIA)
 }
 
 // queryPaths returns paths to dstIA. Unconditionally requests paths from sciond.

--- a/pkg/pan/quic_dial.go
+++ b/pkg/pan/quic_dial.go
@@ -79,6 +79,8 @@ func DialQUIC(ctx context.Context,
 
 	session, err := quic.Dial(ctx, pconn, remote, tlsConf, quicConf)
 	if err != nil {
+		// Close the underlying connection if the QUIC session could not be established.
+		pconn.Close()
 		return nil, err
 	}
 	return &QUICSession{session, conn}, nil

--- a/pkg/pan/refresher.go
+++ b/pkg/pan/refresher.go
@@ -43,7 +43,7 @@ func makeRefresher(pool *pathPool) refresher {
 // subscribe for paths to dst.
 func (r *refresher) subscribe(ctx context.Context, dst IA, s refreshee) ([]*Path, error) {
 	// BUG: oops, this will not inform subscribers of updated paths. Need to explicily check here
-	paths, err := r.pool.paths(ctx, dst)
+	paths, _, err := r.pool.paths(ctx, dst)
 	if err != nil {
 		return nil, err
 	}
@@ -114,8 +114,8 @@ func (r *refresher) refresh() {
 	r.subscribersMutex.Unlock()
 
 	for _, dstIA := range refreshIAs {
-		paths, err := r.pool.paths(context.Background(), dstIA)
-		if err != nil {
+		paths, areFresh, err := r.pool.paths(context.Background(), dstIA)
+		if err != nil || !areFresh {
 			// ignore errors here. The idea is that there is probably a lot of time
 			// until this manifests as an actual problem to the application (i.e.
 			// when the paths actually expire).

--- a/pkg/pan/refresher.go
+++ b/pkg/pan/refresher.go
@@ -105,7 +105,6 @@ func (r *refresher) run() {
 }
 
 func (r *refresher) refresh() {
-	now := time.Now()
 	// when a refresh is triggered, we batch all
 	r.subscribersMutex.Lock()
 	refreshIAs := make([]IA, 0, len(r.subscribers))
@@ -115,30 +114,21 @@ func (r *refresher) refresh() {
 	r.subscribersMutex.Unlock()
 
 	for _, dstIA := range refreshIAs {
-		poolEntry, _ := r.pool.entry(dstIA)
-		if r.shouldRefresh(now, poolEntry.earliestExpiry, poolEntry.lastQuery) {
-			paths, err := r.pool.queryPaths(context.Background(), dstIA)
-			if err != nil {
-				// ignore errors here. The idea is that there is probably a lot of time
-				// until this manifests as an actual problem to the application (i.e.
-				// when the paths actually expire).
-				// TODO: check whether there are errors that could be handled, like try to reconnect
-				// to sciond or something like that.
-				continue
-			}
-			r.subscribersMutex.Lock()
-			for _, subscriber := range r.subscribers[dstIA] {
-				subscriber.refresh(dstIA, paths)
-			}
-			r.subscribersMutex.Unlock()
+		paths, err := r.pool.paths(context.Background(), dstIA)
+		if err != nil {
+			// ignore errors here. The idea is that there is probably a lot of time
+			// until this manifests as an actual problem to the application (i.e.
+			// when the paths actually expire).
+			// TODO: check whether there are errors that could be handled, like try to reconnect
+			// to sciond or something like that.
+			continue
 		}
+		r.subscribersMutex.Lock()
+		for _, subscriber := range r.subscribers[dstIA] {
+			subscriber.refresh(dstIA, paths)
+		}
+		r.subscribersMutex.Unlock()
 	}
-}
-
-func (r *refresher) shouldRefresh(now, expiry, lastQuery time.Time) bool {
-	earliestAllowedRefresh := lastQuery.Add(pathRefreshMinInterval)
-	timeForRefresh := expiry.Add(-pathRefreshLeadTime)
-	return now.After(earliestAllowedRefresh) && now.After(timeForRefresh)
 }
 
 func (r *refresher) untilNextRefresh(prevRefresh time.Time) time.Duration {


### PR DESCRIPTION
There was a bug in the procedure for querying paths, instead of querying paths provided the `pathRefreshMinInterval` had passed, it did it the other way round. I made use of this PR to refactor the internal procedure. In addition, I also added closing the underlay UDPConn if QUIC session was not established successfully.

While troubleshooting the library I also realized that the library is a bit messy and it would be great to spend some effort in refactoring and simplifying it as possible. We kept postponing this, partially, because we discussed about merging [scionproto/snet](https://github.com/scionproto/scion/tree/master/pkg/snet) and the pan library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/259)
<!-- Reviewable:end -->
