### PR TITLE
bump scion version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
             # Link the gen directory containing sciond_addresses.json and as_list.json
             ln -s ~/scion/gen /home/circleci/project/gen
             mkdir gen-cache
+            # Symlink supervisord and supervisorctl to path expected in tools/supervisor.sh
+            ln -s $(which supervisord) bin/supervisord
+            ln -s $(which supervisorctl) bin/supervisorctl
 
             # Start all AS tiny4.topo
             tools/supervisor.sh reload

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -1,8 +1,8 @@
 module examples
 
-go 1.21.10
+go 1.22.7
 
-toolchain go1.21.11
+toolchain go1.22.10
 
 require (
 	github.com/golang/protobuf v1.5.4
@@ -13,7 +13,7 @@ require (
 )
 
 require (
-	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/britram/borat v0.0.0-20181011130314-f891bcfcfb9b // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.14.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b // indirect
+	github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9 h1:zvkJv+9Pxm1nnEMcKnShREt4qtduHKz4iw4AB4ul0Ao=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -116,8 +116,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
+github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486 h1:7hYIHKVxnrrvRvlHYX7cskTvXHCdb6HfFMYyzpZCPmk=
+github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486/go.mod h1:ZZdYvTNhrC3USJOP7XcMFFrwbyoYLGvTKb1L3aIzpxM=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/netsec-ethz/scion-apps
 
-go 1.21.10
+go 1.22.7
 
-toolchain go1.21.11
+toolchain go1.22.10
 
 require (
 	github.com/creack/pty v1.1.17
@@ -14,7 +14,7 @@ require (
 	github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403
 	github.com/pelletier/go-toml v1.9.5
 	github.com/quic-go/quic-go v0.43.1
-	github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b
+	github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.31.0
@@ -25,7 +25,7 @@ require (
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
-	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/britram/borat v0.0.0-20181011130314-f891bcfcfb9b // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9 h1:zvkJv+9Pxm1nnEMcKnShREt4qtduHKz4iw4AB4ul0Ao=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -138,8 +138,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
+github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486 h1:7hYIHKVxnrrvRvlHYX7cskTvXHCdb6HfFMYyzpZCPmk=
+github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486/go.mod h1:ZZdYvTNhrC3USJOP7XcMFFrwbyoYLGvTKb1L3aIzpxM=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=

--- a/pkg/integration/apps.go
+++ b/pkg/integration/apps.go
@@ -77,7 +77,7 @@ func (sai *ScionAppsIntegration) StartServer(ctx context.Context,
 
 	sciondAddr, err := getSCIONDAddress(dst.IA)
 	if err != nil {
-		return nil, serrors.WrapStr("unable to determine SCIOND address", err)
+		return nil, serrors.Wrap("unable to determine SCIOND address", err)
 	}
 	args := replacePattern(SCIOND, sciondAddr, sai.serverArgs)
 	args = replacePattern(DstIAReplace, dst.IA.String(), args)
@@ -103,7 +103,7 @@ func (sai *ScionAppsIntegration) StartServer(ctx context.Context,
 	cmd.Stderr = io.MultiWriter(stderrLog, stderrBuf)
 
 	if err = cmd.Start(); err != nil {
-		return nil, serrors.WrapStr("Failed to start server", err, "dst", dst.IA)
+		return nil, serrors.Wrap("Failed to start server", err, "dst", dst.IA)
 	}
 	select {
 	case <-readyDetector.Signal:
@@ -130,7 +130,7 @@ func (sai *ScionAppsIntegration) StartClient(ctx context.Context,
 
 	sciondAddr, err := getSCIONDAddress(src.IA)
 	if err != nil {
-		return nil, serrors.WrapStr("unable to determine SCIOND address", err)
+		return nil, serrors.Wrap("unable to determine SCIOND address", err)
 	}
 	args := replacePattern(SCIOND, sciondAddr, sai.clientArgs)
 	args = replacePattern(SrcIAReplace, src.IA.String(), args)

--- a/pkg/pan/addr.go
+++ b/pkg/pan/addr.go
@@ -237,8 +237,6 @@ func MangleSCIONAddr(address string) string {
 
 	// Turn this into [IA,IP]:port format. This is a valid host in a URI, as per
 	// the "IP-literal" case in RFC 3986, §3.2.2.
-	// Unfortunately, this is not currently compatible with snet.ParseUDPAddr,
-	// so this will have to be _unmangled_ before use.
 	mangledAddr := fmt.Sprintf("[%s,%s]", raddr.IA, raddr.Host.IP)
 	if raddr.Host.Port != 0 {
 		mangledAddr += fmt.Sprintf(":%d", raddr.Host.Port)

--- a/pkg/pan/addr.go
+++ b/pkg/pan/addr.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"net/netip"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -245,32 +244,4 @@ func MangleSCIONAddr(address string) string {
 		mangledAddr += fmt.Sprintf(":%d", raddr.Host.Port)
 	}
 	return mangledAddr
-}
-
-// UnmangleSCIONAddr returns a SCION address that can be parsed with
-// with snet.ParseUDPAddr.
-// If the input is not a SCION address (e.g. a hostname), the address is
-// returned unchanged.
-// This parses the address, so that it can safely join host and port, with the
-// brackets in the right place. Yes, this means this will be parsed twice.
-//
-// Assumes that address always has a port (this is enforced by the http3
-// roundtripper code)
-func UnmangleSCIONAddr(address string) string {
-	host, port, err := net.SplitHostPort(address)
-	if err != nil || port == "" {
-		panic(fmt.Sprintf("UnmangleSCIONAddr assumes that address is of the form host:port %s", err))
-	}
-	// brackets are removed from [I-A,IP] part by SplitHostPort, so this can be
-	// parsed with ParseUDPAddr:
-	udpAddr, err := snet.ParseUDPAddr(host)
-	if err != nil {
-		return address
-	}
-	p, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		return address
-	}
-	udpAddr.Host.Port = int(p)
-	return udpAddr.String()
 }

--- a/pkg/pan/internal/ping/ping.go
+++ b/pkg/pan/internal/ping/ping.go
@@ -131,7 +131,7 @@ func (p *Pinger) Drain(ctx context.Context) {
 			if err := p.conn.ReadFrom(&pkt, &ov); err != nil && p.errHandler != nil {
 				// Rate limit the error reports.
 				if now := time.Now(); now.Sub(last) > 500*time.Millisecond {
-					p.errHandler(serrors.WrapStr("reading packet", err))
+					p.errHandler(serrors.Wrap("reading packet", err))
 					last = now
 				}
 			}

--- a/pkg/pan/policy.go
+++ b/pkg/pan/policy.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/common"
+	"github.com/scionproto/scion/pkg/segment/iface"
 	"github.com/scionproto/scion/pkg/snet"
 	"github.com/scionproto/scion/private/path/pathpol"
 )
@@ -195,7 +195,7 @@ func (p snetPathWrapper) Metadata() *snet.PathMetadata {
 	for i, spi := range p.wrapped.Metadata.Interfaces {
 		pis[i] = snet.PathInterface{
 			IA: addr.IA(spi.IA),
-			ID: common.IFIDType(spi.IfID), //nolint:staticcheck // False deprecation
+			ID: iface.ID(spi.IfID), //nolint:staticcheck // False deprecation
 		}
 	}
 	return &snet.PathMetadata{

--- a/pkg/pan/policy.go
+++ b/pkg/pan/policy.go
@@ -195,7 +195,7 @@ func (p snetPathWrapper) Metadata() *snet.PathMetadata {
 	for i, spi := range p.wrapped.Metadata.Interfaces {
 		pis[i] = snet.PathInterface{
 			IA: addr.IA(spi.IA),
-			ID: iface.ID(spi.IfID), //nolint:staticcheck // False deprecation
+			ID: iface.ID(spi.IfID),
 		}
 	}
 	return &snet.PathMetadata{

--- a/pkg/shttp/transport.go
+++ b/pkg/shttp/transport.go
@@ -79,7 +79,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Con
 		InsecureSkipVerify: true,
 	}
 
-	remote, err := pan.ResolveUDPAddr(ctx, pan.UnmangleSCIONAddr(addr))
+	remote, err := pan.ResolveUDPAddr(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp/transport_test.go
+++ b/pkg/shttp/transport_test.go
@@ -56,19 +56,9 @@ func TestMangleSCIONAddrURL(t *testing.T) {
 				t.Fatalf("MangleSCIONAddrURL returned different result, actual='%s', expected='%s'", mangled, expected)
 			}
 			// Now attempt to parse this URL. If this fails, the expected test results are broken.
-			u, err := url.Parse(mangled)
+			_, err := url.Parse(mangled)
 			if err != nil {
 				t.Fatalf("MangleSCIONAddrURL returned URL that cannot be parsed: %s", err)
-			}
-
-			// Check that unmangling the address can be parsed by ParseUDPAddr
-			// Only for testcases that have a port set:
-			if _, _, err := net.SplitHostPort(u.Host); err != nil {
-				continue
-			}
-			unmangled := pan.UnmangleSCIONAddr(u.Host)
-			if unmangled != tc.HostPort {
-				t.Fatalf("UnmangleSCIONAddr('%s') returned different result, actual='%s', expected='%s'", u.Host, unmangled, tc.HostPort)
 			}
 		}
 	}
@@ -100,11 +90,10 @@ func TestRoundTripper(t *testing.T) {
 		//  remote, err := pan.ResolveUDPAddr(pan.UnmangleSCIONAddr(addr))
 		// We mock pan.ResolveUDPAddr here; don't want to rely on hosts files etc
 		// for this test.
-		unmangled := pan.UnmangleSCIONAddr(addr)
-		if strings.HasPrefix(unmangled, "host") {
-			_, err := pan.ParseUDPAddr(unmangled)
+		if strings.HasPrefix(addr, "host") {
+			_, err := pan.ParseUDPAddr(addr)
 			require.Error(t, err)
-			hostStr, portStr, err := net.SplitHostPort(unmangled)
+			hostStr, portStr, err := net.SplitHostPort(addr)
 			require.NoError(t, err)
 			port, err := strconv.Atoi(portStr)
 			require.NoError(t, err)
@@ -115,7 +104,7 @@ func TestRoundTripper(t *testing.T) {
 			remote := pan.UDPAddr{IA: hostIA, IP: hostIP, Port: uint16(port)}
 			assert.Equal(t, expected, remote.String())
 		} else {
-			remote, err := pan.ParseUDPAddr(unmangled)
+			remote, err := pan.ParseUDPAddr(addr)
 			require.NoError(t, err)
 			assert.Equal(t, expected, remote.String())
 		}

--- a/pkg/shttp3/transport.go
+++ b/pkg/shttp3/transport.go
@@ -47,7 +47,7 @@ type Dialer struct {
 func (d *Dialer) Dial(ctx context.Context, addr string, tlsCfg *tls.Config,
 	cfg *quic.Config) (quic.EarlyConnection, error) {
 
-	remote, err := pan.ResolveUDPAddr(ctx, pan.UnmangleSCIONAddr(addr))
+	remote, err := pan.ResolveUDPAddr(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/webapp/lib/sciond.go
+++ b/webapp/lib/sciond.go
@@ -34,7 +34,7 @@ import (
 	log "github.com/inconshreveable/log15"
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/daemon"
-	"github.com/scionproto/scion/pkg/private/common"
+	"github.com/scionproto/scion/pkg/segment/iface"
 	"github.com/scionproto/scion/pkg/snet"
 
 	pathdb "github.com/netsec-ethz/scion-apps/webapp/models/path"
@@ -93,7 +93,7 @@ type Path struct {
 
 // Hop represents an hop on the path.
 type Hop struct {
-	IfID common.IFIDType
+	IfID iface.ID
 	IA   addr.IA
 }
 

--- a/webapp/models/path/segments.go
+++ b/webapp/models/path/segments.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/common"
 	"github.com/scionproto/scion/pkg/private/ctrl/path_mgmt/proto"
 	seg "github.com/scionproto/scion/pkg/segment"
+	"github.com/scionproto/scion/pkg/segment/iface"
 	"github.com/scionproto/scion/private/pathdb"
 
 	. "github.com/netsec-ethz/scion-apps/webapp/util"
@@ -29,7 +29,7 @@ import (
 
 type asIface struct {
 	IA    addr.IA
-	IfNum common.IFIDType
+	IfNum iface.ID
 }
 
 type segment struct {
@@ -55,10 +55,10 @@ func newSegment(segType proto.PathSegType, srcIa addr.IA, dstIa addr.IA,
 	for _, ase := range theseg.ASEntries {
 		hof := ase.HopEntry.HopField
 		if hof.ConsIngress > 0 {
-			interfaces = append(interfaces, asIface{ase.Local, common.IFIDType(hof.ConsIngress)})
+			interfaces = append(interfaces, asIface{ase.Local, iface.ID(hof.ConsIngress)})
 		}
 		if hof.ConsEgress > 0 {
-			interfaces = append(interfaces, asIface{ase.Local, common.IFIDType(hof.ConsEgress)})
+			interfaces = append(interfaces, asIface{ase.Local, iface.ID(hof.ConsEgress)})
 		}
 	}
 	return segment{SegType: segType.String(), Src: srcIa, Dst: dstIa,
@@ -113,7 +113,7 @@ func ReadIntfToSegAll(db *sql.DB) (map[int64][]asIface, error) {
 	var segRowID int64
 	var isd addr.ISD
 	var as addr.AS
-	var ifaceID common.IFIDType
+	var ifaceID iface.ID
 	var result = map[int64][]asIface{}
 	for rows.Next() {
 		err = rows.Scan(


### PR DESCRIPTION
This PR removes `UnmangleSCIONAddr()` from the API. I do not think it's being used by any application outside the library. If so I could deprecate it instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/264)
<!-- Reviewable:end -->
