### PR TITLE
pan: fix ListenQUIC to close underlay connection

### DIFF
--- a/_examples/sgrpc/server/main.go
+++ b/_examples/sgrpc/server/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen SCION QUIC on %s: %v", *ServerAddr, err)
 	}
-	lis := quicutil.SingleStreamListener{Listener: quicListener}
+	lis := quicutil.SingleStreamListener{QUICListener: quicListener}
 	log.Println("listen on", quicListener.Addr())
 
 	if err := grpcServer.Serve(lis); err != nil {

--- a/netcat/quic.go
+++ b/netcat/quic.go
@@ -46,7 +46,7 @@ func DoListenQUIC(port uint16) (chan io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	listener := quicutil.SingleStreamListener{Listener: quicListener}
+	listener := quicutil.SingleStreamListener{QUICListener: quicListener}
 
 	conns := make(chan io.ReadWriteCloser)
 	go func() {

--- a/pkg/pan/quic_listen.go
+++ b/pkg/pan/quic_listen.go
@@ -28,12 +28,12 @@ import (
 // underlying connection, which is needed to close it.
 type QUICListener struct {
 	*quic.Listener
-	conn net.PacketConn
+	Conn net.PacketConn
 }
 
 func (l *QUICListener) Close() error {
 	err := l.Listener.Close()
-	l.conn.Close()
+	l.Conn.Close()
 	return err
 }
 
@@ -56,5 +56,5 @@ func ListenQUIC(ctx context.Context, local netip.AddrPort, selector ReplySelecto
 		conn.Close()
 		return nil, err
 	}
-	return &QUICListener{Listener: listener, conn: conn}, nil
+	return &QUICListener{Listener: listener, Conn: conn}, nil
 }

--- a/pkg/quicutil/single.go
+++ b/pkg/quicutil/single.go
@@ -51,7 +51,7 @@ var (
 // SingleStream connections from Accept. This allows to use quic in contexts
 // where a (TCP-)net.Listener is expected.
 type SingleStreamListener struct {
-	*quic.Listener
+	*pan.QUICListener
 }
 
 func (l SingleStreamListener) Accept() (net.Conn, error) {

--- a/pkg/shttp/server.go
+++ b/pkg/shttp/server.go
@@ -96,5 +96,5 @@ func listen(addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	return quicutil.SingleStreamListener{Listener: quicListener}, nil
+	return quicutil.SingleStreamListener{QUICListener: quicListener}, nil
 }

--- a/ssh/client/ssh/ssh.go
+++ b/ssh/client/ssh/ssh.go
@@ -205,7 +205,7 @@ func (client *Client) StartTunnel(local netip.AddrPort, addr string) error {
 		if err != nil {
 			return err
 		}
-		localListener = quicutil.SingleStreamListener{Listener: ql}
+		localListener = quicutil.SingleStreamListener{QUICListener: ql}
 	} else {
 		// That's right, TCP listen on UDPAddr. XXX replace with netip.AddrPort once available
 		tl, err := net.Listen("tcp", local.String())

--- a/ssh/server/main.go
+++ b/ssh/server/main.go
@@ -98,7 +98,7 @@ func main() {
 	if err != nil {
 		golog.Panicf("Failed to listen (%v)", err)
 	}
-	listener := quicutil.SingleStreamListener{Listener: ql}
+	listener := quicutil.SingleStreamListener{QUICListener: ql}
 
 	log.Debug("Starting to wait for connections")
 	for {

--- a/web-gateway/main.go
+++ b/web-gateway/main.go
@@ -160,7 +160,7 @@ func transfer(dst io.WriteCloser, src io.ReadCloser) {
 	}
 }
 
-func listen(laddr netip.AddrPort) (*quic.Listener, error) {
+func listen(laddr netip.AddrPort) (*pan.QUICListener, error) {
 	tlsCfg := &tls.Config{
 		NextProtos:   []string{quicutil.SingleStreamProto},
 		Certificates: quicutil.MustGenerateSelfSignedCert(),


### PR DESCRIPTION
Not sure why this BUG was still lingering, perhaps the solution wasn't that obvious for some reason. If we should not close the underlay connection in some scenario, I guess we could rethink the ListenQUIC() implementation. Currently, I've just added a wrapper that closes the underlay connection when Close() is called on the quic listener. Error handling could be improved as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/265)
<!-- Reviewable:end -->
