### PR TITLE
pan: expose scmpHandler

### DIFF
--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -57,7 +57,7 @@ func runServer(listen netip.AddrPort) error {
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 		NextProtos:   []string{"hello-quic"},
 	}
-	listener, err := pan.ListenQUIC(context.Background(), listen, nil, nil, tlsCfg, nil)
+	listener, err := pan.ListenQUIC(context.Background(), listen, tlsCfg, nil)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func runClient(address string, count int) error {
 		Timeout:  time.Second,
 	}
 	selector.SetActive(2)
-	session, err := pan.DialQUIC(context.Background(), netip.AddrPort{}, addr, nil, selector, nil, "", tlsCfg, nil)
+	session, err := pan.DialQUIC(context.Background(), netip.AddrPort{}, addr, "", tlsCfg, nil, pan.WithSelector(selector))
 	if err != nil {
 		return err
 	}

--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -57,7 +57,7 @@ func runServer(listen netip.AddrPort) error {
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 		NextProtos:   []string{"hello-quic"},
 	}
-	listener, err := pan.ListenQUIC(context.Background(), listen, nil, tlsCfg, nil)
+	listener, err := pan.ListenQUIC(context.Background(), listen, nil, nil, tlsCfg, nil)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func runClient(address string, count int) error {
 		Timeout:  time.Second,
 	}
 	selector.SetActive(2)
-	session, err := pan.DialQUIC(context.Background(), netip.AddrPort{}, addr, nil, selector, "", tlsCfg, nil)
+	session, err := pan.DialQUIC(context.Background(), netip.AddrPort{}, addr, nil, selector, nil, "", tlsCfg, nil)
 	if err != nil {
 		return err
 	}

--- a/_examples/helloworld/helloworld.go
+++ b/_examples/helloworld/helloworld.go
@@ -49,7 +49,7 @@ func main() {
 }
 
 func runServer(listen netip.AddrPort) error {
-	conn, err := pan.ListenUDP(context.Background(), listen, nil)
+	conn, err := pan.ListenUDP(context.Background(), listen, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func runClient(address string, count int) error {
 	if err != nil {
 		return err
 	}
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, addr, nil, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, addr, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/_examples/helloworld/helloworld.go
+++ b/_examples/helloworld/helloworld.go
@@ -49,7 +49,7 @@ func main() {
 }
 
 func runServer(listen netip.AddrPort) error {
-	conn, err := pan.ListenUDP(context.Background(), listen, nil, nil)
+	conn, err := pan.ListenUDP(context.Background(), listen)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func runClient(address string, count int) error {
 	if err != nil {
 		return err
 	}
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, addr, nil, nil, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, addr)
 	if err != nil {
 		return err
 	}

--- a/_examples/sgrpc/client/main.go
+++ b/_examples/sgrpc/client/main.go
@@ -32,7 +32,7 @@ func NewPanQuicDialer(tlsCfg *tls.Config) func(context.Context, string) (net.Con
 		}
 
 		clientQuicConfig := &quic.Config{KeepAlivePeriod: 15 * time.Second}
-		session, err := pan.DialQUIC(ctx, netip.AddrPort{}, panAddr, nil, nil, "", tlsCfg, clientQuicConfig)
+		session, err := pan.DialQUIC(ctx, netip.AddrPort{}, panAddr, nil, nil, nil, "", tlsCfg, clientQuicConfig)
 		if err != nil {
 			return nil, fmt.Errorf("did not dial: %w", err)
 		}

--- a/_examples/sgrpc/client/main.go
+++ b/_examples/sgrpc/client/main.go
@@ -32,7 +32,7 @@ func NewPanQuicDialer(tlsCfg *tls.Config) func(context.Context, string) (net.Con
 		}
 
 		clientQuicConfig := &quic.Config{KeepAlivePeriod: 15 * time.Second}
-		session, err := pan.DialQUIC(ctx, netip.AddrPort{}, panAddr, nil, nil, nil, "", tlsCfg, clientQuicConfig)
+		session, err := pan.DialQUIC(ctx, netip.AddrPort{}, panAddr, "", tlsCfg, clientQuicConfig)
 		if err != nil {
 			return nil, fmt.Errorf("did not dial: %w", err)
 		}

--- a/_examples/sgrpc/server/main.go
+++ b/_examples/sgrpc/server/main.go
@@ -49,7 +49,7 @@ func main() {
 		NextProtos:   []string{"echo_service"},
 	}
 
-	quicListener, err := pan.ListenQUIC(context.Background(), addr, nil, tlsCfg, nil)
+	quicListener, err := pan.ListenQUIC(context.Background(), addr, nil, nil, tlsCfg, nil)
 	if err != nil {
 		log.Fatalf("failed to listen SCION QUIC on %s: %v", *ServerAddr, err)
 	}

--- a/_examples/sgrpc/server/main.go
+++ b/_examples/sgrpc/server/main.go
@@ -49,7 +49,7 @@ func main() {
 		NextProtos:   []string{"echo_service"},
 	}
 
-	quicListener, err := pan.ListenQUIC(context.Background(), addr, nil, nil, tlsCfg, nil)
+	quicListener, err := pan.ListenQUIC(context.Background(), addr, tlsCfg, nil)
 	if err != nil {
 		log.Fatalf("failed to listen SCION QUIC on %s: %v", *ServerAddr, err)
 	}

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -335,7 +335,7 @@ func runBwtest(local netip.AddrPort, serverCCAddr pan.UDPAddr, policy pan.Policy
 
 	// Control channel connection
 	ccSelector := pan.NewDefaultSelector()
-	ccConn, err := pan.DialUDP(context.Background(), local, serverCCAddr, policy, ccSelector, nil)
+	ccConn, err := pan.DialUDP(context.Background(), local, serverCCAddr, pan.WithPolicy(policy), pan.WithSelector(ccSelector))
 	if err != nil {
 		return
 	}
@@ -345,7 +345,7 @@ func runBwtest(local netip.AddrPort, serverCCAddr pan.UDPAddr, policy pan.Policy
 	serverDCAddr := serverCCAddr.WithPort(serverCCAddr.Port + 1)
 
 	// Data channel connection
-	dcConn, err := pan.DialUDP(context.Background(), dcLocal, serverDCAddr, policy, nil, nil)
+	dcConn, err := pan.DialUDP(context.Background(), dcLocal, serverDCAddr, pan.WithPolicy(policy))
 	if err != nil {
 		return
 	}

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -335,7 +335,7 @@ func runBwtest(local netip.AddrPort, serverCCAddr pan.UDPAddr, policy pan.Policy
 
 	// Control channel connection
 	ccSelector := pan.NewDefaultSelector()
-	ccConn, err := pan.DialUDP(context.Background(), local, serverCCAddr, policy, ccSelector)
+	ccConn, err := pan.DialUDP(context.Background(), local, serverCCAddr, policy, ccSelector, nil)
 	if err != nil {
 		return
 	}
@@ -345,7 +345,7 @@ func runBwtest(local netip.AddrPort, serverCCAddr pan.UDPAddr, policy pan.Policy
 	serverDCAddr := serverCCAddr.WithPort(serverCCAddr.Port + 1)
 
 	// Data channel connection
-	dcConn, err := pan.DialUDP(context.Background(), dcLocal, serverDCAddr, policy, nil)
+	dcConn, err := pan.DialUDP(context.Background(), dcLocal, serverDCAddr, policy, nil, nil)
 	if err != nil {
 		return
 	}

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -52,7 +52,7 @@ func runServer(listen netip.AddrPort) error {
 	results := make(resultsMap)
 
 	ccSelector := pan.NewDefaultReplySelector()
-	ccConn, err := pan.ListenUDP(context.Background(), listen, ccSelector, nil)
+	ccConn, err := pan.ListenUDP(context.Background(), listen, pan.WithReplySelector(ccSelector))
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (r resultsMap) purgeExpired() {
 }
 
 func listenConnected(local netip.AddrPort, remote pan.UDPAddr, selector pan.ReplySelector) (net.Conn, error) {
-	conn, err := pan.ListenUDP(context.Background(), local, selector, nil)
+	conn, err := pan.ListenUDP(context.Background(), local, pan.WithReplySelector(selector))
 	return connectedPacketConn{
 		ListenConn: conn,
 		remote:     remote,

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -52,7 +52,7 @@ func runServer(listen netip.AddrPort) error {
 	results := make(resultsMap)
 
 	ccSelector := pan.NewDefaultReplySelector()
-	ccConn, err := pan.ListenUDP(context.Background(), listen, ccSelector)
+	ccConn, err := pan.ListenUDP(context.Background(), listen, ccSelector, nil)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (r resultsMap) purgeExpired() {
 }
 
 func listenConnected(local netip.AddrPort, remote pan.UDPAddr, selector pan.ReplySelector) (net.Conn, error) {
-	conn, err := pan.ListenUDP(context.Background(), local, selector)
+	conn, err := pan.ListenUDP(context.Background(), local, selector, nil)
 	return connectedPacketConn{
 		ListenConn: conn,
 		remote:     remote,

--- a/netcat/quic.go
+++ b/netcat/quic.go
@@ -37,6 +37,7 @@ func DoListenQUIC(port uint16) (chan io.ReadWriteCloser, error) {
 		context.Background(),
 		netip.AddrPortFrom(netip.Addr{}, port),
 		nil,
+		nil,
 		&tls.Config{
 			Certificates: quicutil.MustGenerateSelfSignedCert(),
 			NextProtos:   nextProtos,
@@ -75,6 +76,7 @@ func DoDialQUIC(remote string, policy pan.Policy) (io.ReadWriteCloser, error) {
 		netip.AddrPort{},
 		remoteAddr,
 		policy,
+		nil,
 		nil,
 		pan.MangleSCIONAddr(remote),
 		&tls.Config{

--- a/netcat/quic.go
+++ b/netcat/quic.go
@@ -36,8 +36,6 @@ func DoListenQUIC(port uint16) (chan io.ReadWriteCloser, error) {
 	quicListener, err := pan.ListenQUIC(
 		context.Background(),
 		netip.AddrPortFrom(netip.Addr{}, port),
-		nil,
-		nil,
 		&tls.Config{
 			Certificates: quicutil.MustGenerateSelfSignedCert(),
 			NextProtos:   nextProtos,
@@ -75,15 +73,13 @@ func DoDialQUIC(remote string, policy pan.Policy) (io.ReadWriteCloser, error) {
 		context.Background(),
 		netip.AddrPort{},
 		remoteAddr,
-		policy,
-		nil,
-		nil,
 		pan.MangleSCIONAddr(remote),
 		&tls.Config{
 			InsecureSkipVerify: true,
 			NextProtos:         nextProtos,
 		},
 		&quic.Config{KeepAlivePeriod: 15 * time.Second},
+		pan.WithPolicy(policy),
 	)
 	if err != nil {
 		return nil, err

--- a/netcat/udp.go
+++ b/netcat/udp.go
@@ -58,7 +58,7 @@ func DoDialUDP(remote string, policy pan.Policy) (io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, remoteAddr, policy, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, remoteAddr, policy, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +71,7 @@ func DoListenUDP(port uint16) (chan io.ReadWriteCloser, error) {
 	conn, err := pan.ListenUDP(
 		context.Background(),
 		netip.AddrPortFrom(netip.Addr{}, port),
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/netcat/udp.go
+++ b/netcat/udp.go
@@ -71,8 +71,6 @@ func DoListenUDP(port uint16) (chan io.ReadWriteCloser, error) {
 	conn, err := pan.ListenUDP(
 		context.Background(),
 		netip.AddrPortFrom(netip.Addr{}, port),
-		nil,
-		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/netcat/udp.go
+++ b/netcat/udp.go
@@ -58,7 +58,7 @@ func DoDialUDP(remote string, policy pan.Policy) (io.ReadWriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, remoteAddr, policy, nil, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, remoteAddr, pan.WithPolicy(policy))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/quic_dial.go
+++ b/pkg/pan/quic_dial.go
@@ -21,7 +21,6 @@ import (
 	"net/netip"
 
 	"github.com/quic-go/quic-go"
-	"github.com/scionproto/scion/pkg/snet"
 )
 
 // QUICSession is a wrapper around quic.Connection that always closes the
@@ -57,14 +56,13 @@ func DialQUIC(
 	ctx context.Context,
 	local netip.AddrPort,
 	remote UDPAddr,
-	policy Policy,
-	selector Selector,
-	scmpHandler snet.SCMPHandler,
 	host string,
 	tlsConf *tls.Config,
-	quicConf *quic.Config) (*QUICSession, error) {
+	quicConf *quic.Config,
+	connOptions ...ConnOptions,
+) (*QUICSession, error) {
 
-	conn, err := DialUDP(ctx, local, remote, policy, selector, scmpHandler)
+	conn, err := DialUDP(ctx, local, remote, connOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,15 +97,13 @@ func DialQUICEarly(
 	ctx context.Context,
 	local netip.AddrPort,
 	remote UDPAddr,
-	policy Policy,
-	selector Selector,
-	scmpHandler snet.SCMPHandler,
 	host string,
 	tlsConf *tls.Config,
 	quicConf *quic.Config,
+	connOptions ...ConnOptions,
 ) (*QUICEarlySession, error) {
 
-	conn, err := DialUDP(ctx, local, remote, policy, selector, scmpHandler)
+	conn, err := DialUDP(ctx, local, remote, connOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/quic_dial.go
+++ b/pkg/pan/quic_dial.go
@@ -21,6 +21,7 @@ import (
 	"net/netip"
 
 	"github.com/quic-go/quic-go"
+	"github.com/scionproto/scion/pkg/snet"
 )
 
 // QUICSession is a wrapper around quic.Connection that always closes the
@@ -52,11 +53,18 @@ func (s *QUICEarlySession) CloseWithError(code quic.ApplicationErrorCode, desc s
 //
 // The host parameter is used for SNI.
 // The tls.Config must define an application protocol (using NextProtos).
-func DialQUIC(ctx context.Context,
-	local netip.AddrPort, remote UDPAddr, policy Policy, selector Selector,
-	host string, tlsConf *tls.Config, quicConf *quic.Config) (*QUICSession, error) {
+func DialQUIC(
+	ctx context.Context,
+	local netip.AddrPort,
+	remote UDPAddr,
+	policy Policy,
+	selector Selector,
+	scmpHandler snet.SCMPHandler,
+	host string,
+	tlsConf *tls.Config,
+	quicConf *quic.Config) (*QUICSession, error) {
 
-	conn, err := DialUDP(ctx, local, remote, policy, selector)
+	conn, err := DialUDP(ctx, local, remote, policy, selector, scmpHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -87,11 +95,19 @@ func DialQUIC(ctx context.Context,
 }
 
 // DialQUICEarly establishes a new 0-RTT QUIC connection to a server. Analogous to DialQUIC.
-func DialQUICEarly(ctx context.Context,
-	local netip.AddrPort, remote UDPAddr, policy Policy, selector Selector,
-	host string, tlsConf *tls.Config, quicConf *quic.Config) (*QUICEarlySession, error) {
+func DialQUICEarly(
+	ctx context.Context,
+	local netip.AddrPort,
+	remote UDPAddr,
+	policy Policy,
+	selector Selector,
+	scmpHandler snet.SCMPHandler,
+	host string,
+	tlsConf *tls.Config,
+	quicConf *quic.Config,
+) (*QUICEarlySession, error) {
 
-	conn, err := DialUDP(ctx, local, remote, policy, selector)
+	conn, err := DialUDP(ctx, local, remote, policy, selector, scmpHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/quic_listen.go
+++ b/pkg/pan/quic_listen.go
@@ -21,6 +21,7 @@ import (
 	"net/netip"
 
 	"github.com/quic-go/quic-go"
+	"github.com/scionproto/scion/pkg/snet"
 )
 
 // QUICListener is a wrapper around a quic.Listener that also holds the underlying
@@ -40,10 +41,17 @@ func (l *QUICListener) Close() error {
 // ListenQUIC listens for QUIC connections on a SCION/UDP port.
 //
 // See note on wildcard addresses in the package documentation.
-func ListenQUIC(ctx context.Context, local netip.AddrPort, selector ReplySelector,
-	tlsConf *tls.Config, quicConfig *quic.Config) (*QUICListener, error) {
+//
+// BUG This "leaks" the UDP connection, which is never closed.
+func ListenQUIC(
+	ctx context.Context,
+	local netip.AddrPort,
+	selector ReplySelector,
+	scmpHandler snet.SCMPHandler,
+	tlsConf *tls.Config,
+	quicConfig *quic.Config) (*QUICListener, error) {
 
-	conn, err := ListenUDP(ctx, local, selector)
+	conn, err := ListenUDP(ctx, local, selector, scmpHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/quic_listen.go
+++ b/pkg/pan/quic_listen.go
@@ -21,7 +21,6 @@ import (
 	"net/netip"
 
 	"github.com/quic-go/quic-go"
-	"github.com/scionproto/scion/pkg/snet"
 )
 
 // QUICListener is a wrapper around a quic.Listener that also holds the underlying
@@ -46,12 +45,12 @@ func (l *QUICListener) Close() error {
 func ListenQUIC(
 	ctx context.Context,
 	local netip.AddrPort,
-	selector ReplySelector,
-	scmpHandler snet.SCMPHandler,
 	tlsConf *tls.Config,
-	quicConfig *quic.Config) (*QUICListener, error) {
+	quicConfig *quic.Config,
+	listenConnOptions ...ListenConnOptions,
+) (*QUICListener, error) {
 
-	conn, err := ListenUDP(ctx, local, selector, scmpHandler)
+	conn, err := ListenUDP(ctx, local, listenConnOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pan/quic_listen.go
+++ b/pkg/pan/quic_listen.go
@@ -40,8 +40,6 @@ func (l *QUICListener) Close() error {
 // ListenQUIC listens for QUIC connections on a SCION/UDP port.
 //
 // See note on wildcard addresses in the package documentation.
-//
-// BUG This "leaks" the UDP connection, which is never closed.
 func ListenQUIC(
 	ctx context.Context,
 	local netip.AddrPort,

--- a/pkg/pan/raw.go
+++ b/pkg/pan/raw.go
@@ -152,9 +152,9 @@ func (c *baseUDPConn) Close() error {
 	return c.raw.Close()
 }
 
-type DefaultScmpHandler struct{}
+type DefaultSCMPHandler struct{}
 
-func (h DefaultScmpHandler) Handle(pkt *snet.Packet) error {
+func (h DefaultSCMPHandler) Handle(pkt *snet.Packet) error {
 	scmp := pkt.Payload.(snet.SCMPPayload)
 	switch scmp.Type() {
 	case slayers.SCMPTypeExternalInterfaceDown:

--- a/pkg/pan/raw.go
+++ b/pkg/pan/raw.go
@@ -152,9 +152,9 @@ func (c *baseUDPConn) Close() error {
 	return c.raw.Close()
 }
 
-type scmpHandler struct{}
+type DefaultScmpHandler struct{}
 
-func (h scmpHandler) Handle(pkt *snet.Packet) error {
+func (h DefaultScmpHandler) Handle(pkt *snet.Packet) error {
 	scmp := pkt.Payload.(snet.SCMPPayload)
 	switch scmp.Type() {
 	case slayers.SCMPTypeExternalInterfaceDown:

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -122,7 +122,9 @@ func applyConnOpts(opts []ConnOptions) connOptions {
 		scmpHandler: DefaultScmpHandler{},
 	}
 	for _, opt := range opts {
-		opt(&o)
+		if opt != nil {
+			opt(&o)
+		}
 	}
 	return o
 }

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -92,18 +92,27 @@ func DialUDP(
 
 type ConnOptions func(*connOptions)
 
-func WithSelector(selector Selector) ConnOptions {
-	return func(o *connOptions) {
-		o.selector = selector
-	}
-}
-
+// WithDialSCMPHandler sets the SCMP handler for the connection.
 func WithDialSCMPHandler(handler snet.SCMPHandler) ConnOptions {
 	return func(o *connOptions) {
+		if handler == nil {
+			panic("nil SCMP handler not allowed")
+		}
 		o.scmpHandler = handler
 	}
 }
 
+// WithSelector sets the path selector for the connection.
+func WithSelector(selector Selector) ConnOptions {
+	return func(o *connOptions) {
+		if selector == nil {
+			panic("nil selector not allowed")
+		}
+		o.selector = selector
+	}
+}
+
+// WithPolicy sets the path policy for the connection.
 func WithPolicy(policy Policy) ConnOptions {
 	return func(o *connOptions) {
 		o.policy = policy
@@ -111,15 +120,15 @@ func WithPolicy(policy Policy) ConnOptions {
 }
 
 type connOptions struct {
-	selector    Selector
 	scmpHandler snet.SCMPHandler
+	selector    Selector
 	policy      Policy
 }
 
 func applyConnOpts(opts []ConnOptions) connOptions {
 	o := connOptions{
+		scmpHandler: DefaultSCMPHandler{},
 		selector:    NewDefaultSelector(),
-		scmpHandler: DefaultScmpHandler{},
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -47,17 +47,27 @@ type Conn interface {
 // a path among this set for each Write operation.
 // If the policy is nil, all paths are allowed.
 // If the selector is nil, a DefaultSelector is used.
-func DialUDP(ctx context.Context, local netip.AddrPort, remote UDPAddr,
-	policy Policy, selector Selector) (Conn, error) {
+func DialUDP(
+	ctx context.Context,
+	local netip.AddrPort,
+	remote UDPAddr,
+	policy Policy,
+	selector Selector,
+	scmpHandler snet.SCMPHandler,
+) (Conn, error) {
 
 	local, err := defaultLocalAddr(local)
 	if err != nil {
 		return nil, err
 	}
 
+	if scmpHandler == nil {
+		scmpHandler = DefaultScmpHandler{}
+	}
+
 	sn := snet.SCIONNetwork{
 		Topology:    host().sciond,
-		SCMPHandler: scmpHandler{},
+		SCMPHandler: scmpHandler,
 	}
 	conn, err := sn.OpenRaw(ctx, net.UDPAddrFromAddrPort(local))
 	if err != nil {

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -125,7 +125,9 @@ func apply(opts []ListenConnOptions) listenConnOptions {
 		scmpHandler: DefaultScmpHandler{},
 	}
 	for _, opt := range opts {
-		opt(&o)
+		if opt != nil {
+			opt(&o)
+		}
 	}
 	return o
 }

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -102,27 +102,35 @@ func ListenUDP(
 
 type ListenConnOptions func(*listenConnOptions)
 
-func WithReplySelector(selector ReplySelector) ListenConnOptions {
-	return func(o *listenConnOptions) {
-		o.selector = selector
-	}
-}
-
+// WithListenSCMPHandler sets the SCMP handler for the ListenConn.
 func WithListenSCMPHandler(handler snet.SCMPHandler) ListenConnOptions {
 	return func(o *listenConnOptions) {
+		if handler == nil {
+			panic("nil SCMP handler not allowed")
+		}
 		o.scmpHandler = handler
 	}
 }
 
+// WithReplySelector sets the reply path selector for the ListenConn.
+func WithReplySelector(selector ReplySelector) ListenConnOptions {
+	return func(o *listenConnOptions) {
+		if selector == nil {
+			panic("nil selector not allowed")
+		}
+		o.selector = selector
+	}
+}
+
 type listenConnOptions struct {
-	selector    ReplySelector
 	scmpHandler snet.SCMPHandler
+	selector    ReplySelector
 }
 
 func apply(opts []ListenConnOptions) listenConnOptions {
 	o := listenConnOptions{
+		scmpHandler: DefaultSCMPHandler{},
 		selector:    NewDefaultReplySelector(),
-		scmpHandler: DefaultScmpHandler{},
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/pkg/shttp/server.go
+++ b/pkg/shttp/server.go
@@ -92,7 +92,7 @@ func listen(addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	quicListener, err := pan.ListenQUIC(context.Background(), laddr, nil, tlsCfg, nil)
+	quicListener, err := pan.ListenQUIC(context.Background(), laddr, nil, nil, tlsCfg, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp/server.go
+++ b/pkg/shttp/server.go
@@ -92,7 +92,7 @@ func listen(addr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	quicListener, err := pan.ListenQUIC(context.Background(), laddr, nil, nil, tlsCfg, nil)
+	quicListener, err := pan.ListenQUIC(context.Background(), laddr, tlsCfg, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp/transport.go
+++ b/pkg/shttp/transport.go
@@ -84,7 +84,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Con
 		return nil, err
 	}
 
-	session, err := pan.DialQUIC(ctx, d.Local, remote, d.Policy, nil, addr, tlsCfg, d.QuicConfig)
+	session, err := pan.DialQUIC(ctx, d.Local, remote, d.Policy, nil, nil, addr, tlsCfg, d.QuicConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp/transport.go
+++ b/pkg/shttp/transport.go
@@ -84,7 +84,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Con
 		return nil, err
 	}
 
-	session, err := pan.DialQUIC(ctx, d.Local, remote, d.Policy, nil, nil, addr, tlsCfg, d.QuicConfig)
+	session, err := pan.DialQUIC(ctx, d.Local, remote, addr, tlsCfg, d.QuicConfig, pan.WithPolicy(d.Policy))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp3/server.go
+++ b/pkg/shttp3/server.go
@@ -59,7 +59,7 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	sconn, err := pan.ListenUDP(context.Background(), laddr, nil, nil)
+	sconn, err := pan.ListenUDP(context.Background(), laddr)
 	if err != nil {
 		return err
 	}

--- a/pkg/shttp3/server.go
+++ b/pkg/shttp3/server.go
@@ -59,7 +59,7 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	sconn, err := pan.ListenUDP(context.Background(), laddr, nil)
+	sconn, err := pan.ListenUDP(context.Background(), laddr, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/shttp3/transport.go
+++ b/pkg/shttp3/transport.go
@@ -51,7 +51,7 @@ func (d *Dialer) Dial(ctx context.Context, addr string, tlsCfg *tls.Config,
 	if err != nil {
 		return nil, err
 	}
-	session, err := pan.DialQUICEarly(ctx, d.Local, remote, d.Policy, nil, addr, tlsCfg, cfg)
+	session, err := pan.DialQUICEarly(ctx, d.Local, remote, d.Policy, nil, nil, addr, tlsCfg, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shttp3/transport.go
+++ b/pkg/shttp3/transport.go
@@ -51,7 +51,7 @@ func (d *Dialer) Dial(ctx context.Context, addr string, tlsCfg *tls.Config,
 	if err != nil {
 		return nil, err
 	}
-	session, err := pan.DialQUICEarly(ctx, d.Local, remote, d.Policy, nil, nil, addr, tlsCfg, cfg)
+	session, err := pan.DialQUICEarly(ctx, d.Local, remote, addr, tlsCfg, cfg, pan.WithPolicy(d.Policy))
 	if err != nil {
 		return nil, err
 	}

--- a/sensorapp/sensorfetcher/sensorfetcher.go
+++ b/sensorapp/sensorfetcher/sensorfetcher.go
@@ -54,7 +54,7 @@ func main() {
 	check(err)
 	serverAddr, err := pan.ResolveUDPAddr(context.TODO(), *serverAddrStr)
 	check(err)
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, serverAddr, policy, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, serverAddr, policy, nil, nil)
 	check(err)
 
 	receivePacketBuffer := make([]byte, 2500)

--- a/sensorapp/sensorfetcher/sensorfetcher.go
+++ b/sensorapp/sensorfetcher/sensorfetcher.go
@@ -54,7 +54,7 @@ func main() {
 	check(err)
 	serverAddr, err := pan.ResolveUDPAddr(context.TODO(), *serverAddrStr)
 	check(err)
-	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, serverAddr, policy, nil, nil)
+	conn, err := pan.DialUDP(context.Background(), netip.AddrPort{}, serverAddr, pan.WithPolicy(policy))
 	check(err)
 
 	receivePacketBuffer := make([]byte, 2500)

--- a/sensorapp/sensorserver/sensorserver.go
+++ b/sensorapp/sensorserver/sensorserver.go
@@ -81,7 +81,7 @@ func main() {
 	flag.Parse()
 
 	local := netip.AddrPortFrom(netip.Addr{}, uint16(*port))
-	conn, err := pan.ListenUDP(context.Background(), local, nil)
+	conn, err := pan.ListenUDP(context.Background(), local, nil, nil)
 	check(err)
 
 	receivePacketBuffer := make([]byte, 2500)

--- a/sensorapp/sensorserver/sensorserver.go
+++ b/sensorapp/sensorserver/sensorserver.go
@@ -81,7 +81,7 @@ func main() {
 	flag.Parse()
 
 	local := netip.AddrPortFrom(netip.Addr{}, uint16(*port))
-	conn, err := pan.ListenUDP(context.Background(), local, nil, nil)
+	conn, err := pan.ListenUDP(context.Background(), local)
 	check(err)
 
 	receivePacketBuffer := make([]byte, 2500)

--- a/ssh/client/ssh/scion.go
+++ b/ssh/client/ssh/scion.go
@@ -49,7 +49,7 @@ func dialSCION(ctx context.Context,
 	quicConf := &quic.Config{
 		KeepAlivePeriod: 15 * time.Second,
 	}
-	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, policy, sel, "", tlsConf, quicConf)
+	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, policy, sel, nil, "", tlsConf, quicConf)
 	if err != nil {
 		return nil, err
 	}

--- a/ssh/client/ssh/scion.go
+++ b/ssh/client/ssh/scion.go
@@ -49,7 +49,7 @@ func dialSCION(ctx context.Context,
 	quicConf := &quic.Config{
 		KeepAlivePeriod: 15 * time.Second,
 	}
-	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, policy, sel, nil, "", tlsConf, quicConf)
+	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, "", tlsConf, quicConf, pan.WithPolicy(policy), pan.WithSelector(sel))
 	if err != nil {
 		return nil, err
 	}

--- a/ssh/client/ssh/ssh.go
+++ b/ssh/client/ssh/ssh.go
@@ -201,7 +201,7 @@ func (client *Client) StartTunnel(local netip.AddrPort, addr string) error {
 		tlsConf := &tls.Config{
 			NextProtos: []string{quicutil.SingleStreamProto},
 		}
-		ql, err := pan.ListenQUIC(context.Background(), local, nil, nil, tlsConf, nil)
+		ql, err := pan.ListenQUIC(context.Background(), local, tlsConf, nil)
 		if err != nil {
 			return err
 		}

--- a/ssh/client/ssh/ssh.go
+++ b/ssh/client/ssh/ssh.go
@@ -201,7 +201,7 @@ func (client *Client) StartTunnel(local netip.AddrPort, addr string) error {
 		tlsConf := &tls.Config{
 			NextProtos: []string{quicutil.SingleStreamProto},
 		}
-		ql, err := pan.ListenQUIC(context.Background(), local, nil, tlsConf, nil)
+		ql, err := pan.ListenQUIC(context.Background(), local, nil, nil, tlsConf, nil)
 		if err != nil {
 			return err
 		}

--- a/ssh/server/main.go
+++ b/ssh/server/main.go
@@ -94,7 +94,7 @@ func main() {
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 		NextProtos:   []string{quicutil.SingleStreamProto},
 	}
-	ql, err := pan.ListenQUIC(context.Background(), local, nil, tlsConf, nil)
+	ql, err := pan.ListenQUIC(context.Background(), local, nil, nil, tlsConf, nil)
 	if err != nil {
 		golog.Panicf("Failed to listen (%v)", err)
 	}

--- a/ssh/server/main.go
+++ b/ssh/server/main.go
@@ -94,7 +94,7 @@ func main() {
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 		NextProtos:   []string{quicutil.SingleStreamProto},
 	}
-	ql, err := pan.ListenQUIC(context.Background(), local, nil, nil, tlsConf, nil)
+	ql, err := pan.ListenQUIC(context.Background(), local, tlsConf, nil)
 	if err != nil {
 		golog.Panicf("Failed to listen (%v)", err)
 	}

--- a/ssh/server/ssh/tunnelchannel.go
+++ b/ssh/server/ssh/tunnelchannel.go
@@ -91,7 +91,7 @@ func handleSCIONQUICTunnel(perms *ssh.Permissions, newChannel ssh.NewChannel) er
 		NextProtos:         []string{quicutil.SingleStreamProto},
 		InsecureSkipVerify: true,
 	}
-	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, nil, nil, nil, "", tlsConf, nil)
+	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, "", tlsConf, nil)
 	if err != nil {
 		return fmt.Errorf("could not open remote connection: %w", err)
 	}

--- a/ssh/server/ssh/tunnelchannel.go
+++ b/ssh/server/ssh/tunnelchannel.go
@@ -91,7 +91,7 @@ func handleSCIONQUICTunnel(perms *ssh.Permissions, newChannel ssh.NewChannel) er
 		NextProtos:         []string{quicutil.SingleStreamProto},
 		InsecureSkipVerify: true,
 	}
-	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, nil, nil, "", tlsConf, nil)
+	sess, err := pan.DialQUIC(ctx, netip.AddrPort{}, remote, nil, nil, nil, "", tlsConf, nil)
 	if err != nil {
 		return fmt.Errorf("could not open remote connection: %w", err)
 	}

--- a/web-gateway/main.go
+++ b/web-gateway/main.go
@@ -165,5 +165,5 @@ func listen(laddr netip.AddrPort) (*pan.QUICListener, error) {
 		NextProtos:   []string{quicutil.SingleStreamProto},
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 	}
-	return pan.ListenQUIC(context.Background(), laddr, nil, tlsCfg, nil)
+	return pan.ListenQUIC(context.Background(), laddr, nil, nil, tlsCfg, nil)
 }

--- a/web-gateway/main.go
+++ b/web-gateway/main.go
@@ -165,5 +165,5 @@ func listen(laddr netip.AddrPort) (*pan.QUICListener, error) {
 		NextProtos:   []string{quicutil.SingleStreamProto},
 		Certificates: quicutil.MustGenerateSelfSignedCert(),
 	}
-	return pan.ListenQUIC(context.Background(), laddr, nil, nil, tlsCfg, nil)
+	return pan.ListenQUIC(context.Background(), laddr, tlsCfg, nil)
 }


### PR DESCRIPTION
API BREAKING CHANGE

Currently both `ListenUDP` and `DialUDP` create always a default `scmpHandler` this is not desirable for some applications, especially some servers, that may shut down if they receive an unexpected error, e.g., a SCMPError. We expose now to the applications the `scmpHandler` via functional options pattern, if not provided the application will internally use the defaultScmpHandler, otherwise it will use the one the applications chooses, e.g., an handler that ignores SCMP packets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/266)
<!-- Reviewable:end -->
