### PR TITLE
pan: Fix pool expiry time

### DIFF
--- a/pkg/pan/pool.go
+++ b/pkg/pan/pool.go
@@ -129,6 +129,9 @@ func (e *pathPoolDst) update(paths []*Path) {
 func (p *pathPool) earliestPathExpiry() time.Time {
 	p.entriesMutex.RLock()
 	defer p.entriesMutex.RUnlock()
+	if len(p.entries) == 0 {
+		return time.Time{}
+	}
 	ret := maxTime
 	for _, entry := range p.entries {
 		if entry.earliestExpiry.Before(ret) {
@@ -139,6 +142,9 @@ func (p *pathPool) earliestPathExpiry() time.Time {
 }
 
 func earliestPathExpiry(paths []*Path) time.Time {
+	if len(paths) == 0 {
+		return time.Time{}
+	}
 	ret := maxTime
 	for _, p := range paths {
 		expiry := p.Expiry


### PR DESCRIPTION
Prereq: merge #265 

If the query to sciond returned an empty set of paths, the entry is updated with the empty set. The `update()` method though sets the `e.eralisetExpiry = maxTime`. This makes that `shouldQuery()` returns always false for that destination. I updated it so that it returns the zero value for  `time.Time`. 

Note that we will still wait for `earliestAllowedRefresh`, which it is currently a constant (10 seconds), this may be undesirable for some use cases, i.e., applications that cannot wait for this 10 seconds cool-down period by the cost of issuing more request to the daemon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/267)
<!-- Reviewable:end -->
