### PR TITLE
Fabrid bandwidth tester

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -4,6 +4,8 @@ go 1.21.10
 
 toolchain go1.21.11
 
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc
+
 require (
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/handlers v1.5.1
@@ -43,7 +45,7 @@ require (
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.14.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b // indirect
+	github.com/scionproto/scion v0.12.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -88,6 +88,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403 h1:Ve8YXv3K9Oxlo9c4aQBYXMwe7Dx0Khv5qytdM2qTsco=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403/go.mod h1:YD8WuBUbAoxhvU/keqHboGDpFna9FSvklLLzTZSF7SE=
+github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc h1:tR/SlDQE7yVc5KdGCexNR44a6q6maru/QPz1HmTSVKA=
+github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
 github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
@@ -116,8 +118,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/bat/bat.go
+++ b/bat/bat.go
@@ -103,7 +103,7 @@ func init() {
 	flag.Usage = usage
 	flag.Parse()
 
-	policy, err := pan.PolicyFromCommandline(sequence, preference, interactive)
+	policy, err := pan.PolicyFromCommandline(sequence, preference, interactive, "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/scionproto/scion/pkg/log"
-	"github.com/scionproto/scion/private/path/fabridquery"
 	"math"
 	"net"
 	"net/netip"
@@ -31,6 +29,9 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/scionproto/scion/pkg/log"
+	"github.com/scionproto/scion/private/path/fabridquery"
 
 	"github.com/netsec-ethz/scion-apps/bwtester/bwtest"
 	"github.com/netsec-ethz/scion-apps/pkg/pan"

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -295,7 +295,7 @@ func main() {
 	if !serverCCAddr.IsValid() {
 		usageErr("server address needs to be specified with -s")
 	}
-	policy, err := pan.PolicyFromCommandline(sequence, preference, interactive)
+	policy, err := pan.PolicyFromCommandline(sequence, preference, interactive, fabridQuery)
 	checkUsageErr(err)
 
 	// use default packet size when within same AS

--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -30,7 +30,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/private/path/fabridquery"
 
 	"github.com/netsec-ethz/scion-apps/bwtester/bwtest"

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -20,12 +20,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/scionproto/scion/pkg/log"
 	"net"
 	"net/netip"
 	"os"
 	"time"
 
+	"github.com/scionproto/scion/pkg/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/netsec-ethz/scion-apps/bwtester/bwtest"

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -301,7 +301,7 @@ func listenConnected(local netip.AddrPort, remote pan.UDPAddr, selector pan.Repl
 	var err error
 	var conn pan.ListenConn
 	if enableFabrid {
-		conn, err = pan.ListenUDPWithFabrid(context.Background(), local, selector)
+		conn, err = pan.ListenUDPWithFabrid(context.Background(), local, remote, selector)
 
 	} else {
 		conn, err = pan.ListenUDP(context.Background(), local, selector)

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -18,14 +18,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"net"
 	"net/netip"
-	"os"
 	"time"
 
-	"github.com/scionproto/scion/pkg/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/netsec-ethz/scion-apps/bwtester/bwtest"
@@ -41,13 +38,6 @@ func main() {
 	kingpin.Flag("listen", "Address to listen on").Default(":40002").SetValue(&listen)
 	fabrid := kingpin.Flag("fabrid", "Enable FABRID").Bool()
 	kingpin.Parse()
-	logCfg := log.Config{Console: log.ConsoleConfig{Level: "debug", StacktraceLevel: "none"}}
-	if err := log.Setup(logCfg); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %s", err)
-		flag.Usage()
-		os.Exit(1)
-	}
-	log.Info("Starting server", "fabrid", fabrid)
 
 	err := runServer(listen.Get(), *fabrid)
 	bwtest.Check(err)
@@ -68,6 +58,7 @@ func runServer(listen netip.AddrPort, enableFabrid bool) error {
 		return err
 	}
 	serverCCAddr := ccConn.LocalAddr().(pan.UDPAddr)
+	fmt.Println("Server listening on ", serverCCAddr, " fabrid:", enableFabrid)
 	for {
 		// Handle client requests
 		n, clientCCAddr, err := ccConn.ReadFrom(receivePacketBuffer)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753
+
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.21.10
 
 toolchain go1.21.11
 
+replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc
+
 require (
 	github.com/creack/pty v1.1.17
 	github.com/gorilla/handlers v1.5.1
@@ -14,7 +16,7 @@ require (
 	github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403
 	github.com/pelletier/go-toml v1.9.5
 	github.com/quic-go/quic-go v0.43.1
-	github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b
+	github.com/scionproto/scion v0.12.0
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-replace github.com/scionproto/scion => github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403 h1:Ve8YXv3K9Oxlo9c4aQBYXMwe7Dx0Khv5qytdM2qTsco=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403/go.mod h1:YD8WuBUbAoxhvU/keqHboGDpFna9FSvklLLzTZSF7SE=
-github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753 h1:JdqS4sMU5vUjVMny4Qx/akzAqXdLrhWxTCSIgMmtUGE=
-github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
 github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
@@ -140,6 +138,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
+github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403 h1:Ve8YXv3K9Oxlo9c4aQBYXMwe7Dx0Khv5qytdM2qTsco=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403/go.mod h1:YD8WuBUbAoxhvU/keqHboGDpFna9FSvklLLzTZSF7SE=
+github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc h1:tR/SlDQE7yVc5KdGCexNR44a6q6maru/QPz1HmTSVKA=
+github.com/netsec-ethz/scion v0.6.1-0.20250410094849-bbacd7f940bc/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
 github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
@@ -138,8 +140,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403 h1:Ve8YXv3K9Oxlo9c4aQBYXMwe7Dx0Khv5qytdM2qTsco=
 github.com/netsec-ethz/rains v0.5.1-0.20240619143424-8e9ef27f2403/go.mod h1:YD8WuBUbAoxhvU/keqHboGDpFna9FSvklLLzTZSF7SE=
+github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753 h1:JdqS4sMU5vUjVMny4Qx/akzAqXdLrhWxTCSIgMmtUGE=
+github.com/netsec-ethz/scion v0.6.1-0.20240920134723-b45a8ff2a753/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
 github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
@@ -138,8 +140,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b h1:n4jkPRHGsPC4xNCkVXhOy2qzqUGuMrO6A1zuY1W/2FY=
-github.com/scionproto/scion v0.11.1-0.20240610170620-50b971ca2d4b/go.mod h1:paxrF6VreownCN7E7Rdri6ifXMkiq3leFGoP6n/BFC4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=

--- a/netcat/main.go
+++ b/netcat/main.go
@@ -127,7 +127,7 @@ func main() {
 		}
 	} else {
 		remoteAddr := tail[0]
-		policy, err := pan.PolicyFromCommandline(sequence, preference, interactive)
+		policy, err := pan.PolicyFromCommandline(sequence, preference, interactive, "")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/pan/cli.go
+++ b/pkg/pan/cli.go
@@ -17,6 +17,8 @@ package pan
 import (
 	"fmt"
 	"strings"
+
+	"github.com/scionproto/scion/private/path/fabridquery"
 )
 
 var (
@@ -42,7 +44,7 @@ var (
 //   - an option --preference <preference>, sorting order for paths.
 //     Comma-separated list of available sorting options.
 //   - an option --sequence <sequence>, describing a hop-predicate sequence filter
-func PolicyFromCommandline(sequence string, preference string, interactive bool) (Policy, error) {
+func PolicyFromCommandline(sequence string, preference string, interactive bool, fabridQuery string) (Policy, error) {
 	chain := PolicyChain{}
 	if sequence != "" {
 		seq, err := NewSequence(sequence)
@@ -61,6 +63,15 @@ func PolicyFromCommandline(sequence string, preference string, interactive bool)
 				return nil, fmt.Errorf("unknown preference sorting policy '%s'", preferences[i])
 			}
 		}
+	}
+	if fabridQuery != "" {
+		query, err := fabridquery.ParseFabridQuery(fabridQuery)
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, &FabridPolicySelection{
+			FabridQuery: query,
+		})
 	}
 	if interactive {
 		chain = append(chain, &InteractiveSelection{

--- a/pkg/pan/fabrid.go
+++ b/pkg/pan/fabrid.go
@@ -1,0 +1,52 @@
+// Copyright 2025 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pan
+
+import (
+	"github.com/scionproto/scion/pkg/snet"
+	snetpath "github.com/scionproto/scion/pkg/snet/path"
+	"github.com/scionproto/scion/private/path/fabridquery"
+)
+
+type FabridPolicySelection struct {
+	// The Fabrid query which is used for filtering paths
+	FabridQuery fabridquery.Expressions
+}
+
+// Filters out all paths that do not satisfy the specified FABRID policy
+func (s *FabridPolicySelection) Filter(paths []*Path) []*Path {
+	fabridPaths := []*Path{}
+	for _, p := range paths {
+		_, isSCIONPath := p.ForwardingPath.dataplanePath.(snetpath.SCION)
+		if !isSCIONPath {
+			continue
+		}
+		snetMetadata := snet.PathMetadata{
+			Interfaces: convertInterfaces(p.Metadata.Interfaces),
+			FabridInfo: p.Metadata.FabridInfo}
+		hopIntfs := snetMetadata.Hops()
+		ml := fabridquery.MatchList{
+			SelectedPolicies: make([]*fabridquery.Policy, len(hopIntfs)),
+		}
+		_, pols := s.FabridQuery.Evaluate(hopIntfs, &ml)
+
+		if !pols.Accepted() {
+			continue
+		}
+
+		fabridPaths = append(fabridPaths, p)
+	}
+	return fabridPaths
+}

--- a/pkg/pan/fabrid_server.go
+++ b/pkg/pan/fabrid_server.go
@@ -1,0 +1,90 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pan
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/experimental/fabrid/crypto"
+	"github.com/scionproto/scion/pkg/log"
+	"github.com/scionproto/scion/pkg/private/serrors"
+	"github.com/scionproto/scion/pkg/slayers/extension"
+)
+
+type ClientConnection struct {
+	Source    UDPAddr
+	tmpBuffer []byte
+	pathKey   drkey.Key
+}
+
+type FabridServer struct {
+	Local       UDPAddr
+	Connections map[string]*ClientConnection
+	ASKeyCache  map[addr.IA]drkey.HostASKey
+}
+
+func NewFabridServer(local *UDPAddr) *FabridServer {
+	server := &FabridServer{
+		Local:       *local,
+		Connections: make(map[string]*ClientConnection),
+		ASKeyCache:  make(map[addr.IA]drkey.HostASKey),
+	}
+	return server
+}
+
+func (s *FabridServer) FetchHostHostKey(dstHost UDPAddr,
+	validity time.Time) (drkey.Key, error) {
+	meta := drkey.HostHostMeta{
+		Validity: validity,
+		SrcIA:    addr.IA(s.Local.IA),
+		SrcHost:  s.Local.IP.String(),
+		DstIA:    addr.IA(dstHost.IA),
+		DstHost:  dstHost.IP.String(),
+		ProtoId:  drkey.FABRID,
+	}
+	hostHostKey, err := GetDRKeyHostHostKey(context.Background(), meta)
+	if err != nil {
+		return drkey.Key{}, serrors.WrapStr("getting host key", err)
+	}
+	return hostHostKey.Key, nil
+}
+
+func (s *FabridServer) HandleFabridPacket(remote UDPAddr, fabridOption *extension.FabridOption,
+	identifierOption *extension.IdentifierOption) error {
+	client, found := s.Connections[remote.String()]
+	if !found {
+		pathKey, err := s.FetchHostHostKey(remote, identifierOption.Timestamp)
+		if err != nil {
+			return err
+		}
+		client = &ClientConnection{
+			Source:    remote,
+			tmpBuffer: make([]byte, 192),
+			pathKey:   pathKey,
+		}
+		s.Connections[remote.String()] = client
+		log.Info("Opened new connection", "remote", remote.String())
+	}
+
+	_, err := crypto.VerifyPathValidator(fabridOption,
+		client.tmpBuffer, client.pathKey[:])
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/pan/fabrid_server.go
+++ b/pkg/pan/fabrid_server.go
@@ -76,7 +76,7 @@ func (s *FabridServer) HandleFabridPacket(fabridOption *extension.FabridOption,
 		fmt.Println("Failed to fetch path key. Does your local IP differ from your SD?\nError:", err)
 		return err
 	}
-	_, err = crypto.VerifyPathValidator(fabridOption,
+	_, _, err = crypto.VerifyPathValidator(fabridOption,
 		s.tmpBuffer, s.pathKey.Key[:])
 	if err != nil {
 		fmt.Println("Failed to verify FABRID packet. Error:", err)

--- a/pkg/pan/fabrid_test.go
+++ b/pkg/pan/fabrid_test.go
@@ -1,0 +1,162 @@
+// Copyright 2025 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pan
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/pkg/experimental/fabrid"
+	"github.com/scionproto/scion/pkg/slayers/path"
+	"github.com/scionproto/scion/pkg/slayers/path/scion"
+	"github.com/scionproto/scion/pkg/snet"
+	snetpath "github.com/scionproto/scion/pkg/snet/path"
+	"github.com/scionproto/scion/private/path/fabridquery"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFabridFilter(t *testing.T) {
+	scionDecoded := &scion.Decoded{
+		Base: scion.Base{
+			PathMeta: scion.MetaHdr{
+				CurrHF: 0,
+				SegLen: [3]uint8{3, 0, 0},
+			},
+			NumINF:  1,
+			NumHops: 3,
+		},
+		InfoFields: []path.InfoField{
+			{
+				SegID:   1,
+				ConsDir: true,
+			},
+		},
+		HopFields: []path.HopField{
+			{ConsIngress: 0, ConsEgress: 1},
+			{ConsIngress: 2, ConsEgress: 5},
+			{ConsIngress: 3, ConsEgress: 0},
+		},
+	}
+	raw, err := scionDecoded.ToRaw()
+	assert.NoError(t, err)
+	p := &Path{
+		Source:      MustParseIA("1-ff00:0:1"),
+		Destination: MustParseIA("1-ff00:0:3"),
+		ForwardingPath: ForwardingPath{
+			dataplanePath: snetpath.SCION{
+				Raw: raw.Raw,
+			},
+		},
+		Metadata: &PathMetadata{
+			FabridInfo: []snet.FabridInfo{
+				{
+					Enabled: true,
+					Policies: []*fabrid.Policy{
+						{
+							IsLocal:    false,
+							Identifier: 55,
+							Index:      fabrid.PolicyID(11),
+						},
+						{
+							IsLocal:    false,
+							Identifier: 33,
+							Index:      fabrid.PolicyID(12),
+						},
+					},
+				},
+				{
+					Enabled: true,
+					Policies: []*fabrid.Policy{
+						{
+							IsLocal:    false,
+							Identifier: 55,
+							Index:      fabrid.PolicyID(22),
+						},
+						{
+							IsLocal:    false,
+							Identifier: 33,
+							Index:      fabrid.PolicyID(23),
+						},
+					},
+				},
+				{
+					Enabled: true,
+					Policies: []*fabrid.Policy{
+						{
+							IsLocal:    false,
+							Identifier: 55,
+							Index:      fabrid.PolicyID(33),
+						},
+					},
+				},
+			},
+			Interfaces: []PathInterface{
+				{
+					IA:   MustParseIA("1-ff00:0:1"),
+					IfID: 1,
+				},
+				{
+					IA:   MustParseIA("1-ff00:0:2"),
+					IfID: 2,
+				},
+				{
+					IA:   MustParseIA("1-ff00:0:3"),
+					IfID: 5,
+				},
+				{
+					IA:   MustParseIA("1-ff00:0:3"),
+					IfID: 3,
+				},
+			},
+		},
+	}
+	type testcase struct {
+		name          string
+		query         string
+		expectedPaths int
+	}
+	tests := []testcase{
+		{
+			name:          "query to take any fabrid path",
+			query:         "0-0#0,0@0",
+			expectedPaths: 1,
+		},
+		{
+			name:          "query to take global policy 55 if available",
+			query:         "0-0#0,0@G55",
+			expectedPaths: 1,
+		},
+		{
+			name:          "query to reject the path if global policy 55 is not available",
+			query:         "0-0#0,0@G55+0-0#0,0@REJECT",
+			expectedPaths: 1,
+		},
+		{
+			name:          "query to reject the path if global policy 33 is not available",
+			query:         "0-0#0,0@G33+0-0#0,0@REJECT",
+			expectedPaths: 0,
+		},
+	}
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			q, err := fabridquery.ParseFabridQuery(c.query)
+			assert.NoError(t, err)
+			f := FabridPolicySelection{
+				FabridQuery: q,
+			}
+			res := f.Filter([]*Path{p})
+			assert.Len(t, res, c.expectedPaths)
+		})
+	}
+}

--- a/pkg/pan/path_metadata.go
+++ b/pkg/pan/path_metadata.go
@@ -75,10 +75,14 @@ type PathMetadata struct {
 	// Notes contains the notes added by ASes on the path, in the order of occurrence.
 	// Entry i is the note of AS i on the path.
 	Notes []string
+
+	// FabridInfo contains information about the FABRID policies and support for each hop.
+	FabridInfo []FabridInfo
 }
 
 type GeoCoordinates = snet.GeoCoordinates
 type LinkType = snet.LinkType
+type FabridInfo = snet.FabridInfo
 
 func (pm *PathMetadata) Copy() *PathMetadata {
 	if pm == nil {
@@ -93,6 +97,7 @@ func (pm *PathMetadata) Copy() *PathMetadata {
 		LinkType:     append(pm.LinkType[:0:0], pm.LinkType...),
 		InternalHops: append(pm.InternalHops[:0:0], pm.InternalHops...),
 		Notes:        append(pm.Notes[:0:0], pm.Notes...),
+		FabridInfo:   append(pm.FabridInfo[:0:0], pm.FabridInfo...),
 	}
 }
 

--- a/pkg/pan/raw.go
+++ b/pkg/pan/raw.go
@@ -110,7 +110,7 @@ func (c *baseUDPConn) writeMsg(src, dst UDPAddr, path *Path, b []byte) (int, err
 // readMsg is a helper for reading a single packet.
 // Internally invokes the configured SCMP handler.
 // Ignores non-UDP packets.
-func (c *baseUDPConn) readMsg(b []byte) (int, UDPAddr, ForwardingPath, error) {
+func (c *baseUDPConn) readMsg(b []byte) (int, UDPAddr, ForwardingPath, *slayers.HopByHopExtn, *slayers.EndToEndExtn, error) {
 	c.readMutex.Lock()
 	defer c.readMutex.Unlock()
 	if c.readBuffer == nil {
@@ -124,7 +124,7 @@ func (c *baseUDPConn) readMsg(b []byte) (int, UDPAddr, ForwardingPath, error) {
 		var lastHop net.UDPAddr
 		err := c.raw.ReadFrom(&pkt, &lastHop)
 		if err != nil {
-			return 0, UDPAddr{}, ForwardingPath{}, err
+			return 0, UDPAddr{}, ForwardingPath{}, nil, nil, err
 		}
 		udp, ok := pkt.Payload.(snet.UDPPayload)
 		if !ok {
@@ -144,7 +144,7 @@ func (c *baseUDPConn) readMsg(b []byte) (int, UDPAddr, ForwardingPath, error) {
 			underlay:      underlay,
 		}
 		n := copy(b, udp.Payload)
-		return n, remote, fw, nil
+		return n, remote, fw, pkt.HbhExtension, pkt.E2eExtension, nil
 	}
 }
 

--- a/pkg/pan/sciond.go
+++ b/pkg/pan/sciond.go
@@ -17,6 +17,7 @@ package pan
 import (
 	"context"
 	"fmt"
+	"github.com/scionproto/scion/pkg/drkey"
 	"net"
 	"net/netip"
 	"os"
@@ -146,6 +147,7 @@ func (h *hostContext) queryPaths(ctx context.Context, dst IA) ([]*Path, error) {
 			LinkType:     snetMetadata.LinkType,
 			InternalHops: snetMetadata.InternalHops,
 			Notes:        snetMetadata.Notes,
+			FabridInfo:   snetMetadata.FabridInfo,
 		}
 		underlay := p.UnderlayNextHop().AddrPort()
 		paths[i] = &Path{
@@ -161,6 +163,10 @@ func (h *hostContext) queryPaths(ctx context.Context, dst IA) ([]*Path, error) {
 		}
 	}
 	return paths, nil
+}
+
+func GetDRKeyHostHostKey(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error) {
+	return host().sciond.DRKeyGetHostHostKey(ctx, meta)
 }
 
 func convertPathInterfaceSlice(spis []snet.PathInterface) []PathInterface {

--- a/pkg/pan/sciond.go
+++ b/pkg/pan/sciond.go
@@ -165,8 +165,12 @@ func (h *hostContext) queryPaths(ctx context.Context, dst IA) ([]*Path, error) {
 	return paths, nil
 }
 
-func GetDRKeyHostHostKey(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error) {
-	return host().sciond.DRKeyGetHostHostKey(ctx, meta)
+func (h *hostContext) drkeyGetHostHostKey(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error) {
+	return h.sciond.DRKeyGetHostHostKey(ctx, meta)
+}
+
+func (h *hostContext) fabridKeys() func(ctx context.Context, meta drkey.FabridKeysMeta) (drkey.FabridKeysResponse, error) {
+	return h.sciond.FabridKeys
 }
 
 func convertPathInterfaceSlice(spis []snet.PathInterface) []PathInterface {

--- a/pkg/pan/sciond.go
+++ b/pkg/pan/sciond.go
@@ -17,7 +17,6 @@ package pan
 import (
 	"context"
 	"fmt"
-	"github.com/scionproto/scion/pkg/drkey"
 	"net"
 	"net/netip"
 	"os"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/daemon"
+	"github.com/scionproto/scion/pkg/drkey"
 	"github.com/scionproto/scion/pkg/snet"
 	"github.com/scionproto/scion/pkg/snet/addrutil"
 )

--- a/pkg/pan/selector.go
+++ b/pkg/pan/selector.go
@@ -17,16 +17,16 @@ package pan
 import (
 	"context"
 	"fmt"
-	"github.com/scionproto/scion/pkg/private/common"
-	"github.com/scionproto/scion/pkg/snet"
-	snetpath "github.com/scionproto/scion/pkg/snet/path"
-	"github.com/scionproto/scion/private/path/fabridquery"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/private/common"
+	"github.com/scionproto/scion/pkg/snet"
+	snetpath "github.com/scionproto/scion/pkg/snet/path"
+	"github.com/scionproto/scion/private/path/fabridquery"
 
 	"github.com/netsec-ethz/scion-apps/pkg/pan/internal/ping"
 )
@@ -332,7 +332,6 @@ type FabridSelector struct {
 	mutex        sync.Mutex
 	paths        []*Path
 	current      int
-	activePaths  int
 	fabridQuery  fabridquery.Expressions
 	fabridConfig snetpath.FabridConfig
 	ctx          context.Context

--- a/pkg/pan/selector.go
+++ b/pkg/pan/selector.go
@@ -369,6 +369,13 @@ func (s *FabridSelector) Initialize(local, remote UDPAddr, paths []*Path) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	s.fabridConfig = snetpath.FabridConfig{
+		LocalIA:         addr.IA(local.IA),
+		LocalAddr:       local.IP.String(),
+		DestinationIA:   addr.IA(remote.IA),
+		DestinationAddr: remote.IP.String(),
+	}
+
 	fabridPaths := []*Path{}
 	for _, p := range paths {
 		scionPath, isSCIONPath := p.ForwardingPath.dataplanePath.(snetpath.SCION)
@@ -393,6 +400,7 @@ func (s *FabridSelector) Initialize(local, remote UDPAddr, paths []*Path) {
 			return
 		}
 		p.ForwardingPath.dataplanePath = fabridPath
+		fabridPath.RegisterDRKeyFetcher(host().fabridKeys())
 
 		fabridPaths = append(fabridPaths, p)
 	}

--- a/pkg/pan/selector.go
+++ b/pkg/pan/selector.go
@@ -358,6 +358,7 @@ func convertInterfaces(interfaces []PathInterface) []snet.PathInterface {
 	snetInterfaces := make([]snet.PathInterface, len(interfaces))
 	for i, pathInterface := range interfaces {
 		snetInterfaces[i] = snet.PathInterface{
+			//nolint
 			ID: common.IFIDType(pathInterface.IfID),
 			IA: addr.IA(pathInterface.IA),
 		}
@@ -368,12 +369,12 @@ func convertInterfaces(interfaces []PathInterface) []snet.PathInterface {
 func (s *FabridSelector) Initialize(local, remote UDPAddr, paths []*Path) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
 	s.fabridConfig = snetpath.FabridConfig{
 		LocalIA:         addr.IA(local.IA),
 		LocalAddr:       local.IP.String(),
 		DestinationIA:   addr.IA(remote.IA),
 		DestinationAddr: remote.IP.String(),
+		ValidationRatio: 16,
 	}
 
 	fabridPaths := []*Path{}
@@ -395,12 +396,11 @@ func (s *FabridSelector) Initialize(local, remote UDPAddr, paths []*Path) {
 			continue
 		}
 		fabridPath, err := snetpath.NewFABRIDDataplanePath(scionPath, hopIntfs,
-			pols.Policies(), &s.fabridConfig)
+			pols.Policies(), &s.fabridConfig, host().fabridKeys())
 		if err != nil {
-			return
+			continue
 		}
 		p.ForwardingPath.dataplanePath = fabridPath
-		fabridPath.RegisterDRKeyFetcher(host().fabridKeys())
 
 		fabridPaths = append(fabridPaths, p)
 	}

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -16,10 +16,9 @@ package pan
 
 import (
 	"context"
+	"github.com/scionproto/scion/pkg/snet"
 	"net"
 	"net/netip"
-
-	"github.com/scionproto/scion/pkg/snet"
 )
 
 // Conn represents a _dialed_ connection.
@@ -137,7 +136,7 @@ func (c *dialedConn) WriteVia(path *Path, b []byte) (int, error) {
 
 func (c *dialedConn) Read(b []byte) (int, error) {
 	for {
-		n, remote, _, err := c.baseUDPConn.readMsg(b)
+		n, remote, _, _, _, err := c.baseUDPConn.readMsg(b)
 		if err != nil {
 			return n, err
 		}
@@ -150,7 +149,7 @@ func (c *dialedConn) Read(b []byte) (int, error) {
 
 func (c *dialedConn) ReadVia(b []byte) (int, *Path, error) {
 	for {
-		n, remote, fwPath, err := c.baseUDPConn.readMsg(b)
+		n, remote, fwPath, _, _, err := c.baseUDPConn.readMsg(b)
 		if err != nil {
 			return n, nil, err
 		}

--- a/pkg/pan/udp_dial.go
+++ b/pkg/pan/udp_dial.go
@@ -16,9 +16,10 @@ package pan
 
 import (
 	"context"
-	"github.com/scionproto/scion/pkg/snet"
 	"net"
 	"net/netip"
+
+	"github.com/scionproto/scion/pkg/snet"
 )
 
 // Conn represents a _dialed_ connection.

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -18,15 +18,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/scionproto/scion/pkg/slayers"
-	"github.com/scionproto/scion/pkg/slayers/extension"
-	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"net"
 	"net/netip"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/scionproto/scion/pkg/slayers"
+	"github.com/scionproto/scion/pkg/slayers/extension"
+	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"github.com/scionproto/scion/pkg/snet"
 )
 

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -134,7 +134,7 @@ func ListenUDPWithFabrid(ctx context.Context, local netip.AddrPort, remote UDPAd
 		fmt.Printf("Listening addr=%s\n", localUDPAddr)
 	}
 
-	server := NewFabridServer(localUDPAddr, remote)
+	server := NewFabridServer(ctx, localUDPAddr, remote)
 	return &fabridListenConn{
 		listenConn: listenConn{
 			baseUDPConn: baseUDPConn{
@@ -238,7 +238,10 @@ func (c *fabridListenConn) ReadFromVia(b []byte) (int, UDPAddr, *Path, error) {
 			switch opt.OptType {
 			case slayers.OptTypeIdentifier:
 				decoded := scion.Decoded{}
-				decoded.DecodeFromBytes(fwPath.dataplanePath.(snet.RawPath).Raw)
+				err = decoded.DecodeFromBytes(fwPath.dataplanePath.(snet.RawPath).Raw)
+				if err != nil {
+					return 0, UDPAddr{}, nil, err
+				}
 				baseTimestamp := decoded.InfoFields[0].Timestamp
 				identifierOption, err = extension.ParseIdentifierOption(opt, baseTimestamp)
 				if err != nil {

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/scionproto/scion/pkg/slayers"
+	"github.com/scionproto/scion/pkg/slayers/extension"
+	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"net"
 	"net/netip"
 	"os"
@@ -99,11 +102,62 @@ func ListenUDP(ctx context.Context, local netip.AddrPort,
 	}, nil
 }
 
+func ListenUDPWithFabrid(ctx context.Context, local netip.AddrPort,
+	selector ReplySelector) (ListenConn, error) {
+
+	local, err := defaultLocalAddr(local)
+	if err != nil {
+		return nil, err
+	}
+
+	if selector == nil {
+		selector = NewDefaultReplySelector()
+	}
+	stats.subscribe(selector)
+	sn := snet.SCIONNetwork{
+		Topology:    host().sciond,
+		SCMPHandler: scmpHandler{},
+	}
+	conn, err := sn.OpenRaw(ctx, net.UDPAddrFromAddrPort(local))
+	if err != nil {
+		return nil, err
+	}
+	ipport := conn.LocalAddr().(*net.UDPAddr).AddrPort()
+	localUDPAddr := UDPAddr{
+		IA:   host().ia,
+		IP:   ipport.Addr(),
+		Port: ipport.Port(),
+	}
+	selector.Initialize(localUDPAddr)
+
+	if len(os.Getenv("SCION_GO_INTEGRATION")) > 0 {
+		fmt.Printf("Listening addr=%s\n", localUDPAddr)
+	}
+
+	server := NewFabridServer(&localUDPAddr)
+	return &fabridListenConn{
+		listenConn: listenConn{
+			baseUDPConn: baseUDPConn{
+				raw: conn,
+			},
+			local:    localUDPAddr,
+			selector: selector,
+		},
+		fabridServer: server,
+	}, nil
+}
+
 type listenConn struct {
 	baseUDPConn
 
 	local    UDPAddr
 	selector ReplySelector
+}
+
+type fabridListenConn struct {
+	listenConn
+
+	fabridServer *FabridServer
 }
 
 func (c *listenConn) LocalAddr() net.Addr {
@@ -116,7 +170,7 @@ func (c *listenConn) ReadFrom(b []byte) (int, net.Addr, error) {
 }
 
 func (c *listenConn) ReadFromVia(b []byte) (int, UDPAddr, *Path, error) {
-	n, remote, fwPath, err := c.baseUDPConn.readMsg(b)
+	n, remote, fwPath, _, _, err := c.baseUDPConn.readMsg(b)
 	if err != nil {
 		return n, UDPAddr{}, nil, err
 	}
@@ -160,6 +214,53 @@ func NewDefaultReplySelector() *DefaultReplySelector {
 	return &DefaultReplySelector{
 		remotes: make(map[UDPAddr]remoteEntry),
 	}
+}
+
+func (c *fabridListenConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, remote, _, err := c.ReadFromVia(b)
+	return n, remote, err
+}
+
+func (c *fabridListenConn) ReadFromVia(b []byte) (int, UDPAddr, *Path, error) {
+	n, panRemote, fwPath, hbhExt, _, err := c.baseUDPConn.readMsg(b)
+	if err != nil {
+		return n, UDPAddr{}, nil, err
+	}
+
+	path, err := reversePathFromForwardingPath(panRemote.IA, c.local.IA, fwPath)
+	c.selector.Record(panRemote, path)
+
+	// Check extensions for relevant options
+	var identifierOption *extension.IdentifierOption
+	var fabridOption *extension.FabridOption
+	if hbhExt != nil {
+		for _, opt := range hbhExt.Options {
+			switch opt.OptType {
+			case slayers.OptTypeIdentifier:
+				decoded := scion.Decoded{}
+				decoded.DecodeFromBytes(fwPath.dataplanePath.(snet.RawPath).Raw)
+				baseTimestamp := decoded.InfoFields[0].Timestamp
+				identifierOption, err = extension.ParseIdentifierOption(opt, baseTimestamp)
+				if err != nil {
+					return 0, UDPAddr{}, nil, err
+				}
+			case slayers.OptTypeFabrid:
+				fabridOption, err = extension.ParseFabridOptionFullExtension(opt, (opt.OptDataLen-4)/4)
+				if err != nil {
+					return 0, UDPAddr{}, nil, err
+				}
+			}
+		}
+	}
+	if fabridOption != nil && identifierOption != nil {
+
+		err = c.fabridServer.HandleFabridPacket(panRemote, fabridOption, identifierOption)
+		if err != nil {
+			return 0, UDPAddr{}, nil, err
+		}
+	}
+
+	return n, panRemote, path, err
 }
 
 func (s *DefaultReplySelector) Initialize(local UDPAddr) {

--- a/pkg/pan/udp_listen.go
+++ b/pkg/pan/udp_listen.go
@@ -102,7 +102,7 @@ func ListenUDP(ctx context.Context, local netip.AddrPort,
 	}, nil
 }
 
-func ListenUDPWithFabrid(ctx context.Context, local netip.AddrPort,
+func ListenUDPWithFabrid(ctx context.Context, local netip.AddrPort, remote UDPAddr,
 	selector ReplySelector) (ListenConn, error) {
 
 	local, err := defaultLocalAddr(local)
@@ -134,7 +134,7 @@ func ListenUDPWithFabrid(ctx context.Context, local netip.AddrPort,
 		fmt.Printf("Listening addr=%s\n", localUDPAddr)
 	}
 
-	server := NewFabridServer(&localUDPAddr)
+	server := NewFabridServer(localUDPAddr, remote)
 	return &fabridListenConn{
 		listenConn: listenConn{
 			baseUDPConn: baseUDPConn{
@@ -254,7 +254,7 @@ func (c *fabridListenConn) ReadFromVia(b []byte) (int, UDPAddr, *Path, error) {
 	}
 	if fabridOption != nil && identifierOption != nil {
 
-		err = c.fabridServer.HandleFabridPacket(panRemote, fabridOption, identifierOption)
+		err = c.fabridServer.HandleFabridPacket(fabridOption, identifierOption)
 		if err != nil {
 			return 0, UDPAddr{}, nil, err
 		}

--- a/sensorapp/sensorfetcher/sensorfetcher.go
+++ b/sensorapp/sensorfetcher/sensorfetcher.go
@@ -50,7 +50,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	policy, err := pan.PolicyFromCommandline(*sequence, *preference, *interactive)
+	policy, err := pan.PolicyFromCommandline(*sequence, *preference, *interactive, "")
 	check(err)
 	serverAddr, err := pan.ResolveUDPAddr(context.TODO(), *serverAddrStr)
 	check(err)

--- a/ssh/client/main.go
+++ b/ssh/client/main.go
@@ -151,7 +151,7 @@ func main() {
 		golog.Panicf("Error creating ssh client: %v", err)
 	}
 
-	policy, err := pan.PolicyFromCommandline(*sequence, *preference, *interactive)
+	policy, err := pan.PolicyFromCommandline(*sequence, *preference, *interactive, "")
 	if err != nil {
 		golog.Fatal(err)
 	}


### PR DESCRIPTION
Contains code that allows to use FABRID for the bandwidth tester.
Since FABRID currently only exists in the netsec-ethz/scion repository, but not in the scionproto repository, go redirects the dependencies to the netsec-ethz/scion repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-apps/273)
<!-- Reviewable:end -->
