### PR TITLE
Treat transport error 0x0 correctly in helloquic

### DIFF
--- a/_examples/helloquic/helloquic.go
+++ b/_examples/helloquic/helloquic.go
@@ -72,8 +72,11 @@ func runServer(listen netip.AddrPort) error {
 		fmt.Println("New session", session.RemoteAddr())
 		go func() {
 			err := workSession(session)
-			var errApplication *quic.ApplicationError
-			if err != nil && !(errors.As(err, &errApplication) && errApplication.ErrorCode == 0) {
+			var (
+				errApplication *quic.ApplicationError
+				errTransport *quic.TransportError
+			)
+			if err != nil && !(errors.As(err, &errApplication) && errApplication.ErrorCode == 0) && !(errors.As(err, &errTransport) && errTransport.ErrorCode == 0) {
 				fmt.Println("Error in session", session.RemoteAddr(), err)
 			}
 		}()


### PR DESCRIPTION
I've noticed that when running my own SCION QUIC client against the example QUIC server in `_examples/helloquic/helloquic.go` that when my client closes the connection the server logs an error. Looking closer at the example server implementation I've noticed that the example server does not correctly handle the transport error code 0x0. According to [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000#section-20.1) the transport error code 0x0 means `NO_ERROR` and can be used to abruptly close the connection. Hence, I think this error code should be ignored by the server and not logged.